### PR TITLE
Remove `@escaping` attribute from `ReceivedArguments` and `ReceivedInvocations` 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 /.build
 /.swiftpm
+/Examples/.swiftpm
 /Packages
 /*.swiftinterface
 /*.xcodeproj

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -64,15 +64,25 @@ struct ReceivedInvocationsFactory {
     private func arrayElementType(parameterList: FunctionParameterListSyntax) -> TypeSyntaxProtocol {
         let arrayElementType: TypeSyntaxProtocol
 
-        if parameterList.count == 1, let onlyParameter = parameterList.first {
-            arrayElementType = onlyParameter.type
+        if parameterList.count == 1, var onlyParameterType = parameterList.first?.type {
+            if let attributedType = onlyParameterType.as(AttributedTypeSyntax.self) {
+                onlyParameterType = attributedType.baseType
+            }
+
+            arrayElementType = onlyParameterType
         } else {
             let tupleElements = TupleTypeElementListSyntax {
                 for parameter in parameterList {
                     TupleTypeElementSyntax(
                         name: parameter.secondName ?? parameter.firstName,
                         colon: .colonToken(),
-                        type: parameter.type
+                        type: {
+                            if let attributedType = parameter.type.as(AttributedTypeSyntax.self) {
+                                return attributedType.baseType
+                            } else {
+                                return parameter.type
+                            }
+                        }()
                     )
                 }
             }

--- a/Tests/SpyableMacroTests/Assertions/AssertBuildResult.swift
+++ b/Tests/SpyableMacroTests/Assertions/AssertBuildResult.swift
@@ -6,22 +6,22 @@ import _SwiftSyntaxTestSupport
  Source: https://github.com/apple/swift-syntax/blob/4db7cb20e63f4dba0b030068687996723e352874/Tests/SwiftSyntaxBuilderTest/Assertions.swift#L19
  */
 func assertBuildResult<T: SyntaxProtocol>(
-  _ buildable: T,
-  _ expectedResult: String,
-  trimTrailingWhitespace: Bool = true,
-  file: StaticString = #file,
-  line: UInt = #line
+    _ buildable: T,
+    _ expectedResult: String,
+    trimTrailingWhitespace: Bool = true,
+    file: StaticString = #file,
+    line: UInt = #line
 ) {
-  var buildableDescription = buildable.formatted().description
-  var expectedResult = expectedResult
-  if trimTrailingWhitespace {
-    buildableDescription = buildableDescription.trimmingTrailingWhitespace()
-    expectedResult = expectedResult.trimmingTrailingWhitespace()
-  }
-  assertStringsEqualWithDiff(
-    buildableDescription,
-    expectedResult,
-    file: file,
-    line: line
-  )
+    var buildableDescription = buildable.formatted().description
+    var expectedResult = expectedResult
+    if trimTrailingWhitespace {
+        buildableDescription = buildableDescription.trimmingTrailingWhitespace()
+        expectedResult = expectedResult.trimmingTrailingWhitespace()
+    }
+    assertStringsEqualWithDiff(
+        buildableDescription,
+        expectedResult,
+        file: file,
+        line: line
+    )
 }

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
@@ -60,6 +60,63 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
         )
     }
 
+    func testVariableDeclarationSingleArgumentWithEscapingAttribute() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: @escaping () -> Void)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedCompletion: (() -> Void)?
+            """
+        )
+    }
+
+    func testVariableDeclarationSingleClosureArgument() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: () -> Void)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedCompletion: (() -> Void)?
+            """
+        )
+    }
+
+    func testVariableDeclarationSingleOptionalClosureArgument() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: (() -> Void)?)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedCompletion: (() -> Void)?
+            """
+        )
+    }
+
     func testVariableDeclarationMultiArguments() throws {
         let variablePrefix = "foo"
         let functionDeclaration = try FunctionDeclSyntax(
@@ -75,6 +132,63 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
             result,
             """
             var fooReceivedArguments: (text: String, count: (x: Int, UInt?)?, price: Decimal?)?
+            """
+        )
+    }
+
+    func testVariableDeclarationMultiArgumentsWithEscapingAttribute() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: @escaping () -> Void, _ count: (x: Int, UInt?)?, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedArguments: (completion: () -> Void, count: (x: Int, UInt?)?, price: Decimal?)?
+            """
+        )
+    }
+
+    func testVariableDeclarationMultiArgumentsWithSomeClosureArgument() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: () -> Void, _ count: (x: Int, UInt?)?, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedArguments: (completion: () -> Void, count: (x: Int, UInt?)?, price: Decimal?)?
+            """
+        )
+    }
+
+    func testVariableDeclarationMultiArgumentsWithSomeOptionalClosureArgument() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: (() -> Void)?, _ count: (x: Int, UInt?)?, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedArguments: (completion: (() -> Void)?, count: (x: Int, UInt?)?, price: Decimal?)?
             """
         )
     }

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
@@ -3,6 +3,9 @@ import XCTest
 import SwiftSyntax
 
 final class UT_ReceivedArgumentsFactory: XCTestCase {
+
+    // MARK: - Variable Declaration
+
     func testVariableDeclarationSingleArgument() throws {
         let variablePrefix = "foo"
         let functionDeclaration = try FunctionDeclSyntax(
@@ -64,6 +67,25 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
         let variablePrefix = "foo"
         let functionDeclaration = try FunctionDeclSyntax(
             "func foo(completion: @escaping () -> Void)"
+        ) {}
+
+        let result = ReceivedArgumentsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedCompletion: (() -> Void)?
+            """
+        )
+    }
+
+    func testVariableDeclarationSingleArgumentWithEscapingAttributeAndTuple() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: @escaping (() -> Void))"
         ) {}
 
         let result = ReceivedArgumentsFactory().variableDeclaration(
@@ -192,6 +214,8 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
             """
         )
     }
+
+    // MARK: - Assign Value To Variable Expression
 
     func testAssignValueToVariableExpressionSingleArgumentFirstParameterName() throws {
         let variablePrefix = "funcName"

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
@@ -3,6 +3,9 @@ import XCTest
 import SwiftSyntax
 
 final class UT_ReceivedInvocationsFactory: XCTestCase {
+
+    // MARK: - Variable Declaration
+
     func testVariableDeclarationSingleArgument() throws {
         let variablePrefix = "foo"
         let functionDeclaration = try FunctionDeclSyntax(
@@ -41,6 +44,63 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
         )
     }
 
+    func testVariableDeclarationSingleArgumentWithEscapingAttribute() throws {
+        let variablePrefix = "bar"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func bar(completion: @escaping () -> Void)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var barReceivedInvocations: [() -> Void] = []
+            """
+        )
+    }
+
+    func testVariableDeclarationSingleClosureArgument() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: () -> Void)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedInvocations: [() -> Void] = []
+            """
+        )
+    }
+
+    func testVariableDeclarationSingleOptionalClosureArgument() throws {
+        let variablePrefix = "name"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func name(completion: (() -> Void)?)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var nameReceivedInvocations: [(() -> Void)?] = []
+            """
+        )
+    }
+
     func testVariableDeclarationMultiArguments() throws {
         let variablePrefix = "func_name"
         let functionDeclaration = try FunctionDeclSyntax(
@@ -59,6 +119,65 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
             """
         )
     }
+
+    func testVariableDeclarationMultiArgumentsWithEscapingAttribute() throws {
+        let variablePrefix = "foo"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func foo(completion: @escaping () -> Void, count: UInt, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var fooReceivedInvocations: [(completion: () -> Void, count: UInt, price: Decimal?)] = []
+            """
+        )
+    }
+
+    func testVariableDeclarationMultiArgumentsWithSomeClosureArgument() throws {
+        let variablePrefix = "bar"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func bar(completion: () -> Void, _ count: (x: Int, UInt?)?, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var barReceivedInvocations: [(completion: () -> Void, count: (x: Int, UInt?)?, price: Decimal?)] = []
+            """
+        )
+    }
+
+    func testVariableDeclarationMultiArgumentsWithSomeOptionalClosureArgument() throws {
+        let variablePrefix = "func_name"
+        let functionDeclaration = try FunctionDeclSyntax(
+            "func func_name(completion: (() -> Void)?, _ count: (x: Int, UInt?)?, final price: Decimal?)"
+        ) {}
+
+        let result = ReceivedInvocationsFactory().variableDeclaration(
+            variablePrefix: variablePrefix,
+            parameterList: functionDeclaration.signature.input.parameterList
+        )
+
+        assertBuildResult(
+            result,
+            """
+            var func_nameReceivedInvocations: [(completion: (() -> Void)?, count: (x: Int, UInt?)?, price: Decimal?)] = []
+            """
+        )
+    }
+
+    // MARK: - Append Value To Variable Expression
 
     func testAppendValueToVariableExpressionSingleArgument() throws {
         let variablePrefix = "funcName"


### PR DESCRIPTION
An update to the .gitignore file to exclude the Examples/.swiftpm folder.

Modifications to the ReceivedArgumentsFactory.swift file, improving the handling of optional and function types. Specifically, the PR addresses scenarios where there is only one parameter, handling optional types and function types separately. If the parameter type is a function, it's wrapped in an optional and tuple type. The underlying base type is used instead if the parameter type is attributed (e.g., has the @escaping attribute).

Similar changes to ReceivedInvocationsFactory.swift, improving the handling of optional and function types in the parameter list.

The UT_ReceivedArgumentsFactory.swift file has been updated with additional unit tests to verify the new functionality in ReceivedArgumentsFactory. This includes tests for single arguments with the @escaping attribute, single closure arguments, optional closure arguments, and multi-arguments with the @escaping attribute​.