### PR TITLE
Added a git mailmap file to consolidate authors

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Mateusz Bąk <44930823+Matejkob@users.noreply.github.com>


### PR DESCRIPTION
After seeing your name just now, it reminded me that I spotted a slight issue with this repo on SPI. You have a couple of different authors showing. We use `git shortlog -sne` to determine this information, and a `.mailmap` file can fix it up!

![Screenshot 2023-08-08 at 13 14 29@2x](https://github.com/Matejkob/swift-spyable/assets/5180/d5e90470-5a7d-49f9-ab95-440bb49ce2d3)

It may be a little cheeky for me to assume you want to do this, but just in case, here's a PR!