### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Sources/SpyableMacro/Factories/CallsCountFactory.swift
+++ b/Sources/SpyableMacro/Factories/CallsCountFactory.swift
@@ -30,7 +30,7 @@ struct CallsCountFactory {
                         identifier: variableIdentifier(variablePrefix: variablePrefix)
                     ),
                     initializer: InitializerClauseSyntax(
-                        value: IntegerLiteralExprSyntax(digits: .integerLiteral("0"))
+                        value: IntegerLiteralExprSyntax(literal: .integerLiteral("0"))
                     )
                 )
             }
@@ -39,9 +39,9 @@ struct CallsCountFactory {
 
     func incrementVariableExpression(variablePrefix: String) -> SequenceExprSyntax {
         SequenceExprSyntax {
-            IdentifierExprSyntax(identifier: variableIdentifier(variablePrefix: variablePrefix))
-            BinaryOperatorExprSyntax(operatorToken: .binaryOperator("+="))
-            IntegerLiteralExprSyntax(digits: .integerLiteral("1"))
+            DeclReferenceExprSyntax(baseName: variableIdentifier(variablePrefix: variablePrefix))
+            BinaryOperatorExprSyntax(operator: .binaryOperator("+="))
+            IntegerLiteralExprSyntax(literal: .integerLiteral("1"))
         }
     }
 

--- a/Sources/SpyableMacro/Factories/CallsCountFactory.swift
+++ b/Sources/SpyableMacro/Factories/CallsCountFactory.swift
@@ -23,7 +23,7 @@ import SwiftSyntaxBuilder
 struct CallsCountFactory {
     func variableDeclaration(variablePrefix: String) -> VariableDeclSyntax {
         VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(

--- a/Sources/SpyableMacro/Factories/ClosureFactory.swift
+++ b/Sources/SpyableMacro/Factories/ClosureFactory.swift
@@ -35,8 +35,8 @@ struct ClosureFactory {
         let elements = TupleTypeElementListSyntax {
             TupleTypeElementSyntax(
                 type: FunctionTypeSyntax(
-                    arguments: TupleTypeElementListSyntax {
-                        for parameter in functionSignature.input.parameterList {
+                    parameters: TupleTypeElementListSyntax {
+                        for parameter in functionSignature.parameterClause.parameters {
                             TupleTypeElementSyntax(type: parameter.type)
                         }
                     },
@@ -44,8 +44,8 @@ struct ClosureFactory {
                         asyncSpecifier: functionSignature.effectSpecifiers?.asyncSpecifier,
                         throwsSpecifier: functionSignature.effectSpecifiers?.throwsSpecifier
                     ),
-                    output: functionSignature.output ?? ReturnClauseSyntax(
-                        returnType: SimpleTypeIdentifierSyntax(
+                    returnClause: functionSignature.returnClause ?? ReturnClauseSyntax(
+                        type: IdentifierTypeSyntax(
                             name: .identifier("Void")
                         )
                     )
@@ -77,16 +77,16 @@ struct ClosureFactory {
     func callExpression(variablePrefix: String, functionSignature: FunctionSignatureSyntax) -> ExprSyntaxProtocol {
         let calledExpression: ExprSyntaxProtocol
 
-        if functionSignature.output == nil {
+        if functionSignature.returnClause == nil {
             calledExpression = OptionalChainingExprSyntax(
-                expression: IdentifierExprSyntax(
-                    identifier: variableIdentifier(variablePrefix: variablePrefix)
+                expression: DeclReferenceExprSyntax(
+                    baseName: variableIdentifier(variablePrefix: variablePrefix)
                 )
             )
         } else {
-            calledExpression = ForcedValueExprSyntax(
-                expression: IdentifierExprSyntax(
-                    identifier: variableIdentifier(variablePrefix: variablePrefix)
+            calledExpression = ForceUnwrapExprSyntax(
+                expression: DeclReferenceExprSyntax(
+                    baseName: variableIdentifier(variablePrefix: variablePrefix)
                 )
             )
         }
@@ -94,11 +94,11 @@ struct ClosureFactory {
         var expression: ExprSyntaxProtocol = FunctionCallExprSyntax(
             calledExpression: calledExpression,
             leftParen: .leftParenToken(),
-            argumentList: TupleExprElementListSyntax {
-                for parameter in functionSignature.input.parameterList {                    
-                    TupleExprElementSyntax(
-                        expression: IdentifierExprSyntax(
-                            identifier: parameter.secondName ?? parameter.firstName
+            arguments: LabeledExprListSyntax {
+                for parameter in functionSignature.parameterClause.parameters {                    
+                    LabeledExprSyntax(
+                        expression: DeclReferenceExprSyntax(
+                            baseName: parameter.secondName ?? parameter.firstName
                         )
                     )
                 }

--- a/Sources/SpyableMacro/Factories/ClosureFactory.swift
+++ b/Sources/SpyableMacro/Factories/ClosureFactory.swift
@@ -62,7 +62,7 @@ struct ClosureFactory {
         )
 
         return VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(

--- a/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
@@ -71,12 +71,12 @@ struct FunctionImplementationFactory {
             attributes: protocolFunctionDeclaration.attributes,
             modifiers: protocolFunctionDeclaration.modifiers,
             funcKeyword: protocolFunctionDeclaration.funcKeyword,
-            identifier: protocolFunctionDeclaration.identifier,
+            name: protocolFunctionDeclaration.name,
             genericParameterClause: protocolFunctionDeclaration.genericParameterClause,
             signature: protocolFunctionDeclaration.signature,
             genericWhereClause: protocolFunctionDeclaration.genericWhereClause,
             bodyBuilder: {
-                let parameterList = protocolFunctionDeclaration.signature.input.parameterList
+                let parameterList = protocolFunctionDeclaration.signature.parameterClause.parameters
 
                 callsCountFactory.incrementVariableExpression(variablePrefix: variablePrefix)
 
@@ -95,7 +95,7 @@ struct FunctionImplementationFactory {
                     throwableErrorFactory.throwErrorExpression(variablePrefix: variablePrefix)
                 }
 
-                if protocolFunctionDeclaration.signature.output == nil {
+                if protocolFunctionDeclaration.signature.returnClause == nil {
                     closureFactory.callExpression(
                         variablePrefix: variablePrefix,
                         functionSignature: protocolFunctionDeclaration.signature
@@ -117,8 +117,8 @@ struct FunctionImplementationFactory {
                     condition: .expression(
                         ExprSyntax(
                             SequenceExprSyntax {
-                                IdentifierExprSyntax(identifier: .identifier(variablePrefix + "Closure"))
-                                BinaryOperatorExprSyntax(operatorToken: .binaryOperator("!="))
+                                DeclReferenceExprSyntax(baseName: .identifier(variablePrefix + "Closure"))
+                                BinaryOperatorExprSyntax(operator: .binaryOperator("!="))
                                 NilLiteralExprSyntax()
                             }
                         )

--- a/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
@@ -82,7 +82,7 @@ struct ReceivedArgumentsFactory {
             let tupleElements = TupleTypeElementListSyntax {
                 for parameter in parameterList {
                     TupleTypeElementSyntax(
-                        name: parameter.secondName ?? parameter.firstName,
+                        firstName: parameter.secondName ?? parameter.firstName,
                         colon: .colonToken(),
                         type: {
                             if let attributedType = parameter.type.as(AttributedTypeSyntax.self) {
@@ -107,13 +107,13 @@ struct ReceivedArgumentsFactory {
         let identifier = variableIdentifier(variablePrefix: variablePrefix, parameterList: parameterList)
 
         return SequenceExprSyntax {
-            IdentifierExprSyntax(identifier: identifier)
+            DeclReferenceExprSyntax(baseName: identifier)
             AssignmentExprSyntax()
             TupleExprSyntax {
                 for parameter in parameterList {
-                    TupleExprElementSyntax(
-                        expression: IdentifierExprSyntax(
-                            identifier: parameter.secondName ?? parameter.firstName
+                    LabeledExprSyntax(
+                        expression: DeclReferenceExprSyntax(
+                            baseName: parameter.secondName ?? parameter.firstName
                         )
                     )
                 }

--- a/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
@@ -41,7 +41,7 @@ struct ReceivedArgumentsFactory {
         let type = variableType(parameterList: parameterList)
 
         return VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: identifier),

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -51,7 +51,7 @@ struct ReceivedInvocationsFactory {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: identifier),
                     typeAnnotation: TypeAnnotationSyntax(
-                        type: ArrayTypeSyntax(elementType: elementType)
+                        type: ArrayTypeSyntax(element: elementType)
                     ),
                     initializer: InitializerClauseSyntax(
                         value: ArrayExprSyntax(elementsBuilder: {})
@@ -95,7 +95,7 @@ struct ReceivedInvocationsFactory {
     func appendValueToVariableExpression(variablePrefix: String, parameterList: FunctionParameterListSyntax) -> FunctionCallExprSyntax {
         let identifier = variableIdentifier(variablePrefix: variablePrefix)
         let calledExpression = MemberAccessExprSyntax(
-            base: IdentifierExprSyntax(identifier: identifier),
+            base: DeclReferenceExprSyntax(baseName: identifier),
             dot: .periodToken(),
             name: .identifier("append")
         )
@@ -104,26 +104,26 @@ struct ReceivedInvocationsFactory {
         return FunctionCallExprSyntax(
             calledExpression: calledExpression,
             leftParen: .leftParenToken(),
-            argumentList: argument,
+            arguments: argument,
             rightParen: .rightParenToken()
         )
     }
 
-    private func appendArgumentExpression(parameterList: FunctionParameterListSyntax) -> TupleExprElementListSyntax {
+    private func appendArgumentExpression(parameterList: FunctionParameterListSyntax) -> LabeledExprListSyntax {
         let tupleArgument = TupleExprSyntax(
             elementListBuilder: {
                 for parameter in parameterList {
-                    TupleExprElementSyntax(
-                        expression: IdentifierExprSyntax(
-                            identifier: parameter.secondName ?? parameter.firstName
+                    LabeledExprSyntax(
+                        expression: DeclReferenceExprSyntax(
+                            baseName: parameter.secondName ?? parameter.firstName
                         )
                     )
                 }
             }
         )
 
-        return TupleExprElementListSyntax {
-            TupleExprElementSyntax(expression: tupleArgument)
+        return LabeledExprListSyntax {
+            LabeledExprSyntax(expression: tupleArgument)
         }
     }
 

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -74,7 +74,7 @@ struct ReceivedInvocationsFactory {
             let tupleElements = TupleTypeElementListSyntax {
                 for parameter in parameterList {
                     TupleTypeElementSyntax(
-                        name: parameter.secondName ?? parameter.firstName,
+                        firstName: parameter.secondName ?? parameter.firstName,
                         colon: .colonToken(),
                         type: {
                             if let attributedType = parameter.type.as(AttributedTypeSyntax.self) {

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -111,15 +111,17 @@ struct ReceivedInvocationsFactory {
 
     private func appendArgumentExpression(parameterList: FunctionParameterListSyntax) -> LabeledExprListSyntax {
         let tupleArgument = TupleExprSyntax(
-            elementListBuilder: {
-                for parameter in parameterList {
-                    LabeledExprSyntax(
-                        expression: DeclReferenceExprSyntax(
-                            baseName: parameter.secondName ?? parameter.firstName
+            elements: LabeledExprListSyntax(
+                itemsBuilder: {
+                    for parameter in parameterList {
+                        LabeledExprSyntax(
+                            expression: DeclReferenceExprSyntax(
+                                baseName: parameter.secondName ?? parameter.firstName
+                            )
                         )
-                    )
+                    }
                 }
-            }
+            )
         )
 
         return LabeledExprListSyntax {

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -46,7 +46,7 @@ struct ReceivedInvocationsFactory {
         let elementType = arrayElementType(parameterList: parameterList)
 
         return VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(identifier: identifier),

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -96,7 +96,7 @@ struct ReceivedInvocationsFactory {
         let identifier = variableIdentifier(variablePrefix: variablePrefix)
         let calledExpression = MemberAccessExprSyntax(
             base: DeclReferenceExprSyntax(baseName: identifier),
-            dot: .periodToken(),
+            period: .periodToken(),
             name: .identifier("append")
         )
         let argument = appendArgumentExpression(parameterList: parameterList)

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -40,7 +40,7 @@ import SwiftSyntaxBuilder
 struct ReturnValueFactory {
     func variableDeclaration(variablePrefix: String, functionReturnType: TypeSyntax) -> VariableDeclSyntax {
         VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -63,7 +63,7 @@ struct ReturnValueFactory {
     func returnStatement(variablePrefix: String) -> ReturnStmtSyntax {
         ReturnStmtSyntax(
             returnKeyword: .keyword(.return),
-            expression: IdentifierExprSyntax(identifier: variableIdentifier(variablePrefix: variablePrefix))
+            expression: DeclReferenceExprSyntax(baseName: variableIdentifier(variablePrefix: variablePrefix))
         )
     }
 

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -92,7 +92,7 @@ struct SpyFactory {
     private let functionImplementationFactory = FunctionImplementationFactory()
 
     func classDeclaration(for protocolDeclaration: ProtocolDeclSyntax) -> ClassDeclSyntax {
-        let identifier = TokenSyntax.identifier(protocolDeclaration.identifier.text + "Spy")
+        let identifier = TokenSyntax.identifier(protocolDeclaration.name.text + "Spy")
 
         let variableDeclarations = protocolDeclaration.memberBlock.members
             .compactMap { $0.decl.as(VariableDeclSyntax.self) }
@@ -102,9 +102,9 @@ struct SpyFactory {
         
         return ClassDeclSyntax(
             identifier: identifier,
-            inheritanceClause: TypeInheritanceClauseSyntax {
+            inheritanceClause: InheritanceClauseSyntax {
                 InheritedTypeSyntax(
-                    typeName: SimpleTypeIdentifierSyntax(name: protocolDeclaration.identifier)
+                    type: IdentifierTypeSyntax(name: protocolDeclaration.name)
                 )
             },
             memberBlockBuilder: {
@@ -116,7 +116,7 @@ struct SpyFactory {
 
                 for functionDeclaration in functionDeclarations {
                     let variablePrefix = variablePrefixFactory.text(for: functionDeclaration)
-                    let parameterList = functionDeclaration.signature.input.parameterList
+                    let parameterList = functionDeclaration.signature.parameterClause.parameters
 
                     callsCountFactory.variableDeclaration(variablePrefix: variablePrefix)
                     calledFactory.variableDeclaration(variablePrefix: variablePrefix)
@@ -136,7 +136,7 @@ struct SpyFactory {
                         throwableErrorFactory.variableDeclaration(variablePrefix: variablePrefix)
                     }
 
-                    if let returnType = functionDeclaration.signature.output?.returnType {
+                    if let returnType = functionDeclaration.signature.returnClause?.type {
                         returnValueFactory.variableDeclaration(
                             variablePrefix: variablePrefix,
                             functionReturnType: returnType

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -101,7 +101,7 @@ struct SpyFactory {
             .compactMap { $0.decl.as(FunctionDeclSyntax.self) }
         
         return ClassDeclSyntax(
-            identifier: identifier,
+            name: identifier,
             inheritanceClause: InheritanceClauseSyntax {
                 InheritedTypeSyntax(
                     type: IdentifierTypeSyntax(name: protocolDeclaration.name)

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -31,7 +31,7 @@ import SwiftSyntaxBuilder
 struct ThrowableErrorFactory {
     func variableDeclaration(variablePrefix: String) -> VariableDeclSyntax {
         VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -39,7 +39,7 @@ struct ThrowableErrorFactory {
                     ),
                     typeAnnotation: TypeAnnotationSyntax(
                         type: OptionalTypeSyntax(
-                            wrappedType: SimpleTypeIdentifierSyntax(name: .identifier("Error"))
+                            wrappedType: IdentifierTypeSyntax(name: .identifier("Error"))
                         )
                     )
                 )
@@ -53,7 +53,7 @@ struct ThrowableErrorFactory {
                 ConditionElementSyntax(
                     condition: .optionalBinding(
                         OptionalBindingConditionSyntax(
-                           bindingKeyword: .keyword(.let),
+                            bindingSpecifier: .keyword(.let),
                            pattern: IdentifierPatternSyntax(
                                identifier: variableIdentifier(variablePrefix: variablePrefix)
                            )
@@ -63,8 +63,8 @@ struct ThrowableErrorFactory {
             },
             bodyBuilder: {
                 ThrowStmtSyntax(
-                    expression: IdentifierExprSyntax(
-                        identifier: variableIdentifier(variablePrefix: variablePrefix)
+                    expression: DeclReferenceExprSyntax(
+                        baseName: variableIdentifier(variablePrefix: variablePrefix)
                     )
                 )
             }

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -54,10 +54,10 @@ struct ThrowableErrorFactory {
                     condition: .optionalBinding(
                         OptionalBindingConditionSyntax(
                             bindingSpecifier: .keyword(.let),
-                           pattern: IdentifierPatternSyntax(
-                               identifier: variableIdentifier(variablePrefix: variablePrefix)
-                           )
-                       )
+                            pattern: IdentifierPatternSyntax(
+                                identifier: variableIdentifier(variablePrefix: variablePrefix)
+                            )
+                        )
                     )
                 )
             },

--- a/Sources/SpyableMacro/Factories/VariablePrefixFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablePrefixFactory.swift
@@ -19,9 +19,9 @@ import SwiftSyntaxBuilder
 /// Please note that if a parameter is underscored (anonymous), it's ignored.
 struct VariablePrefixFactory {
     func text(for functionDeclaration: FunctionDeclSyntax) -> String {
-        var parts: [String] = [functionDeclaration.identifier.text]
+        var parts: [String] = [functionDeclaration.name.text]
 
-        let parameterList = functionDeclaration.signature.input.parameterList
+        let parameterList = functionDeclaration.signature.parameterClause.parameters
 
         let parameters = parameterList
             .map { $0.firstName.text }

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -46,7 +46,7 @@ struct VariablesImplementationFactory {
     @MemberBlockItemListBuilder
     func variablesDeclarations(
         protocolVariableDeclaration: VariableDeclSyntax
-    ) -> MemberDeclListSyntax {
+    ) -> MemberBlockItemListSyntax {
         if let binding = protocolVariableDeclaration.bindings.first {
             if let variableType = binding.typeAnnotation?.type, variableType.is(OptionalTypeSyntax.self) {
                 accessorRemovalVisitor.visit(protocolVariableDeclaration)
@@ -125,6 +125,6 @@ struct VariablesImplementationFactory {
 private class AccessorRemovalVisitor: SyntaxRewriter {
     override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
         let superResult = super.visit(node)
-        return superResult.with(\.accessor, nil)
+        return superResult.with(\.accessorBlock, nil)
     }
 }

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -89,7 +89,7 @@ struct VariablesImplementationFactory {
         binding: PatternBindingListSyntax.Element
     ) -> VariableDeclSyntax {
         VariableDeclSyntax(
-            bindingKeyword: .keyword(.var),
+            bindingSpecifier: .keyword(.var),
             bindingsBuilder: {
                 PatternBindingSyntax(
                     pattern: IdentifierPatternSyntax(


### PR DESCRIPTION
**Context**
I'm interested in using and contributing to this library a bit, but I saw there were a bunch of deprecation warnings. Most of them could be resolved with fix-its, and the few ones that didn't have fix-its weren't too bad. Figured I'd fix them to make the repo nicer to work in without all the ⚠️.

**Testing**
Existing tests pass
![Screenshot 2023-10-28 at 12 49 25 PM](https://github.com/Matejkob/swift-spyable/assets/10556242/6ec341f2-a06b-4b63-b181-a67f001cbafe)
