### PR TITLE
Fix leading spacing on property and function declaration expansion

### DIFF
--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -102,10 +102,10 @@ struct SpyFactory {
       associatedtypeDeclList: assosciatedtypeDeclarations)
 
     let variableDeclarations = protocolDeclaration.memberBlock.members
-      .compactMap { $0.decl.as(VariableDeclSyntax.self) }
+      .compactMap { $0.decl.as(VariableDeclSyntax.self)?.removingLeadingSpaces }
 
     let functionDeclarations = protocolDeclaration.memberBlock.members
-      .compactMap { $0.decl.as(FunctionDeclSyntax.self) }
+      .compactMap { $0.decl.as(FunctionDeclSyntax.self)?.removingLeadingSpaces }
 
     return try ClassDeclSyntax(
       name: identifier,
@@ -162,6 +162,24 @@ struct SpyFactory {
           )
         }
       }
+    )
+  }
+}
+
+private extension SyntaxProtocol {
+  /// - Returns: `self` with leading space `Trivia` removed.
+  var removingLeadingSpaces: Self {
+    with(
+      \.leadingTrivia, Trivia(
+        pieces: leadingTrivia
+          .filter {
+            if case .spaces = $0 {
+              false
+            } else {
+              true
+            }
+          }
+       )
     )
   }
 }

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -64,7 +64,7 @@ final class UT_SpyableMacro: XCTestCase {
                 }
             }
             var underlyingAnyProtocol: (any Codable)!
-                var secondName: String?
+            var secondName: String?
             var added: () -> Void {
                 get {
                     underlyingAdded
@@ -74,7 +74,7 @@ final class UT_SpyableMacro: XCTestCase {
                 }
             }
             var underlyingAdded: (() -> Void)!
-                var removed: (() -> Void)?
+            var removed: (() -> Void)?
             var logoutCallsCount = 0
             var logoutCalled: Bool {
                 return logoutCallsCount > 0
@@ -91,7 +91,7 @@ final class UT_SpyableMacro: XCTestCase {
             var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
             var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
             var initializeNameSecondNameClosure: ((String, String?) -> Void)?
-                func initialize(name: String, secondName: String?) {
+            func initialize(name: String, secondName: String?) {
                 initializeNameSecondNameCallsCount += 1
                 initializeNameSecondNameReceivedArguments = (name, secondName)
                 initializeNameSecondNameReceivedInvocations.append((name, secondName))
@@ -104,7 +104,7 @@ final class UT_SpyableMacro: XCTestCase {
             var fetchConfigThrowableError: (any Error)?
             var fetchConfigReturnValue: [String: String]!
             var fetchConfigClosure: (() async throws -> [String: String])?
-                func fetchConfig() async throws -> [String: String] {
+            func fetchConfig() async throws -> [String: String] {
                 fetchConfigCallsCount += 1
                 if let fetchConfigThrowableError {
                     throw fetchConfigThrowableError
@@ -123,7 +123,7 @@ final class UT_SpyableMacro: XCTestCase {
             var fetchDataReceivedInvocations: [(String, count: Int)] = []
             var fetchDataReturnValue: (() -> Void)!
             var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
-                func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
+            func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
                 fetchDataCallsCount += 1
                 fetchDataReceivedName = (name)
                 fetchDataReceivedInvocations.append((name))


### PR DESCRIPTION
**Context**
Indentation and spacing was a little off in some Macro expansion, so I wanted to make it more readable.

Given the example protocol:
```swift
@Spyable
public protocol ServiceProtocol {
    var name: String {
        get
    }
    var secondName: String? {
        get
    }

    func initialize(name: String, secondName: String?)
}
```

This is the expansion in `main`:
```swift
class ServiceProtocolSpy: ServiceProtocol {
    var name: String {
        get {
            underlyingName
        }
        set {
            underlyingName = newValue
        }
    }
    var underlyingName: (String )! ⬅️❌
        var secondName: String? ⬅️❌
    var initializeNameSecondNameCallsCount = 0
    var initializeNameSecondNameCalled: Bool {
        return initializeNameSecondNameCallsCount > 0
    }
    var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
    var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
    var initializeNameSecondNameClosure: ((String, String?) -> Void)?

        func initialize(name: String, secondName: String?) { ⬅️❌
        initializeNameSecondNameCallsCount += 1
        initializeNameSecondNameReceivedArguments = (name, secondName)
        initializeNameSecondNameReceivedInvocations.append((name, secondName))
        initializeNameSecondNameClosure?(name, secondName)
    }
}
```
And this is the expansion in this PR:
```swift
class ServiceProtocolSpy: ServiceProtocol {
    var name: String {
        get {
            underlyingName
        }
        set {
            underlyingName = newValue
        }
    }
    var underlyingName: (String)! ⬅️✅
    var secondName: String? ⬅️✅
    var initializeNameSecondNameCallsCount = 0
    var initializeNameSecondNameCalled: Bool {
        return initializeNameSecondNameCallsCount > 0
    }
    var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
    var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
    var initializeNameSecondNameClosure: ((String, String?) -> Void)?

    func initialize(name: String, secondName: String?) { ⬅️✅
        initializeNameSecondNameCallsCount += 1
        initializeNameSecondNameReceivedArguments = (name, secondName)
        initializeNameSecondNameReceivedInvocations.append((name, secondName))
        initializeNameSecondNameClosure?(name, secondName)
    }
}
```

**Testing**
Existing tests pass, and the adjusted tests pass.
![Screenshot 2023-10-28 at 2 02 57 PM](https://github.com/Matejkob/swift-spyable/assets/10556242/55c72520-3649-4645-967c-f031c6948da8)