### PR TITLE
Emit `(any Error)?` instead of `Error?`

### DIFF
--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -60,7 +60,7 @@ import SwiftSyntaxBuilder
 ///     }
 ///     var fetchTextCountReceivedArguments: (text: String, count: Int)?
 ///     var fetchTextCountReceivedInvocations: [(text: String, count: Int)] = []
-///     var fetchTextCountThrowableError: Error?
+///     var fetchTextCountThrowableError: (any Error)?
 ///     var fetchTextCountReturnValue: Decimal!
 ///     var fetchTextCountClosure: ((String, Int) async throws -> Decimal)?
 ///

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -13,7 +13,7 @@ import SwiftSyntaxBuilder
 ///
 /// The following code:
 /// ```swift
-/// var fooThrowableError: Error?
+/// var fooThrowableError: (any Error)?
 ///
 /// if let fooThrowableError {
 ///     throw fooThrowableError
@@ -32,7 +32,7 @@ struct ThrowableErrorFactory {
   func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(
       """
-      var \(variableIdentifier(variablePrefix: variablePrefix)): Error?
+      var \(variableIdentifier(variablePrefix: variablePrefix)): (any Error)?
       """
     )
   }

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -184,7 +184,7 @@ final class UT_SpyFactory: XCTestCase {
           }
           var fooReceivedAdded: ((text: String) -> Void)?
           var fooReceivedInvocations: [((text: String) -> Void)?] = []
-          var fooThrowableError: Error?
+          var fooThrowableError: (any Error)?
           var fooReturnValue: (() -> Int)?
           var fooClosure: ((((text: String) -> Void)?) throws -> (() -> Int)?)?
           func foo(_ added: ((text: String) -> Void)?) throws -> (() -> Int)? {

--- a/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
@@ -12,7 +12,7 @@ final class UT_ThrowableErrorFactory: XCTestCase {
     assertBuildResult(
       result,
       """
-      var functionNameThrowableError: Error?
+      var functionNameThrowableError: (any Error)?
       """
     )
   }

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -101,7 +101,7 @@ final class UT_SpyableMacro: XCTestCase {
             var fetchConfigCalled: Bool {
                 return fetchConfigCallsCount > 0
             }
-            var fetchConfigThrowableError: Error?
+            var fetchConfigThrowableError: (any Error)?
             var fetchConfigReturnValue: [String: String]!
             var fetchConfigClosure: (() async throws -> [String: String])?
                 func fetchConfig() async throws -> [String: String] {


### PR DESCRIPTION
This is a change to support [SE-0335](https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md), and specifically the use of the currently optional[^currently_optional] compiler flag `-enable-upcoming-feature ExistentialAny`. Some projects enable this flag in order to future-proof their code against a requirement to use the `any P` syntax, and this change makes the code this macro produces compatible with that choice, while remaining compatible with the default settings of the compiler as well.

This change only affects the `Error` types emitted by `throws` functions. Other protocol existential types emitted by `@Spyable` are unchanged by this PR. Those should be addressed in a future PR.

[^currently_optional]: It's expected that this `any P` syntax will be required in a future language mode of Swift, but it isn't currently required. `any P` has the exact same meaning as `P` where `P` is the name of a protocol.