### PR TITLE
Declare the spy as public if the protocol is declared public

### DIFF
--- a/Sources/SpyableMacro/Factories/CalledFactory.swift
+++ b/Sources/SpyableMacro/Factories/CalledFactory.swift
@@ -25,10 +25,10 @@ import SwiftSyntaxBuilder
 /// ```
 /// and an argument `variablePrefix` equal to `foo`.
 struct CalledFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
+    func variableDeclaration(variablePrefix: String, isPublic: Bool) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(
       """
-      var \(raw: variablePrefix)Called: Bool {
+      \(raw: isPublic ? "public " : "")var \(raw: variablePrefix)Called: Bool {
           return \(raw: variablePrefix)CallsCount > 0
       }
       """

--- a/Sources/SpyableMacro/Factories/CallsCountFactory.swift
+++ b/Sources/SpyableMacro/Factories/CallsCountFactory.swift
@@ -21,10 +21,10 @@ import SwiftSyntaxBuilder
 /// ```
 /// and an argument `variablePrefix` equal to `foo`.
 struct CallsCountFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
+    func variableDeclaration(variablePrefix: String, isPublic: Bool) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(
       """
-      var \(variableIdentifier(variablePrefix: variablePrefix)) = 0
+      \(raw: isPublic ? "public " : "")var \(variableIdentifier(variablePrefix: variablePrefix)) = 0
       """
     )
   }

--- a/Sources/SpyableMacro/Factories/ClosureFactory.swift
+++ b/Sources/SpyableMacro/Factories/ClosureFactory.swift
@@ -30,6 +30,7 @@ import SwiftSyntaxBuilder
 struct ClosureFactory {
   func variableDeclaration(
     variablePrefix: String,
+    isPublic: Bool,
     functionSignature: FunctionSignatureSyntax
   ) throws -> VariableDeclSyntax {
     let elements = TupleTypeElementListSyntax {
@@ -56,7 +57,7 @@ struct ClosureFactory {
 
     return try VariableDeclSyntax(
       """
-      var \(variableIdentifier(variablePrefix: variablePrefix)): (\(elements))?
+      \(raw: isPublic ? "public " : "")var \(variableIdentifier(variablePrefix: variablePrefix)): (\(elements))?
       """
     )
   }

--- a/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
@@ -65,11 +65,16 @@ struct FunctionImplementationFactory {
 
   func declaration(
     variablePrefix: String,
+    isPublic: Bool,
     protocolFunctionDeclaration: FunctionDeclSyntax
   ) -> FunctionDeclSyntax {
-    var spyFunctionDeclaration = protocolFunctionDeclaration
+    var spyFunctionDeclaration = protocolFunctionDeclaration.trimmed
 
     spyFunctionDeclaration.modifiers = protocolFunctionDeclaration.modifiers.removingMutatingKeyword
+    
+    if isPublic {
+      spyFunctionDeclaration.modifiers.addPublicAccess()
+    }
 
     spyFunctionDeclaration.body = CodeBlockSyntax {
       let parameterList = protocolFunctionDeclaration.signature.parameterClause.parameters
@@ -148,5 +153,9 @@ struct FunctionImplementationFactory {
 extension DeclModifierListSyntax {
   fileprivate var removingMutatingKeyword: Self {
     filter { $0.name.text != TokenSyntax.keyword(.mutating).text }
+  }
+  
+  fileprivate mutating func addPublicAccess() {
+    append(DeclModifierSyntax(name: .keyword(.public)))
   }
 }

--- a/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
@@ -38,6 +38,7 @@ import SwiftSyntaxBuilder
 struct ReceivedArgumentsFactory {
   func variableDeclaration(
     variablePrefix: String,
+    isPublic: Bool,
     parameterList: FunctionParameterListSyntax
   ) throws -> VariableDeclSyntax {
     let identifier = variableIdentifier(
@@ -48,7 +49,7 @@ struct ReceivedArgumentsFactory {
 
     return try VariableDeclSyntax(
       """
-      var \(identifier): \(type)
+      \(raw: isPublic ? "public " : "")var \(identifier): \(type)
       """
     )
   }

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -43,6 +43,7 @@ import SwiftSyntaxBuilder
 struct ReceivedInvocationsFactory {
   func variableDeclaration(
     variablePrefix: String,
+    isPublic: Bool,
     parameterList: FunctionParameterListSyntax
   ) throws -> VariableDeclSyntax {
     let identifier = variableIdentifier(variablePrefix: variablePrefix)
@@ -50,7 +51,7 @@ struct ReceivedInvocationsFactory {
 
     return try VariableDeclSyntax(
       """
-      var \(identifier): [\(elementType)] = []
+      \(raw: isPublic ? "public " : "")var \(identifier): [\(elementType)] = []
       """
     )
   }

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -40,6 +40,7 @@ import SwiftSyntaxBuilder
 struct ReturnValueFactory {
   func variableDeclaration(
     variablePrefix: String,
+    isPublic: Bool,
     functionReturnType: TypeSyntax
   ) throws -> VariableDeclSyntax {
     let typeAnnotation =
@@ -53,7 +54,7 @@ struct ReturnValueFactory {
 
     return try VariableDeclSyntax(
       """
-      var \(variableIdentifier(variablePrefix: variablePrefix))\(typeAnnotation)
+      \(raw: isPublic ? "public " : "")var \(variableIdentifier(variablePrefix: variablePrefix))\(typeAnnotation)
       """
     )
   }

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -123,13 +123,18 @@ struct SpyFactory {
         )
       },
       memberBlockBuilder: {
+        
+        if isPublic {
+          DeclSyntax(stringLiteral: "public init() {}")
+        }
+        
         for variableDeclaration in variableDeclarations {
           try variablesImplementationFactory.variablesDeclarations(
             protocolVariableDeclaration: variableDeclaration,
             isPublic: isPublic
           )
         }
-
+        
         for functionDeclaration in functionDeclarations {
           let variablePrefix = variablePrefixFactory.text(for: functionDeclaration)
           let parameterList = functionDeclaration.signature.parameterClause.parameters

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -108,6 +108,7 @@ struct SpyFactory {
       .compactMap { $0.decl.as(FunctionDeclSyntax.self) }
 
     return try ClassDeclSyntax(
+      modifiers: protocolDeclaration.modifiers,
       name: identifier,
       genericParameterClause: genericParameterClause,
       inheritanceClause: InheritanceClauseSyntax {

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -29,10 +29,10 @@ import SwiftSyntaxBuilder
 ///         your tests. You can use it to simulate different scenarios and verify that your code handles
 ///         errors correctly.
 struct ThrowableErrorFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
+    func variableDeclaration(variablePrefix: String, isPublic: Bool) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(
       """
-      var \(variableIdentifier(variablePrefix: variablePrefix)): (any Error)?
+      \(raw: isPublic ? "public ": "")var \(variableIdentifier(variablePrefix: variablePrefix)): (any Error)?
       """
     )
   }

--- a/Tests/SpyableMacroTests/Factories/UT_CalledFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_CalledFactory.swift
@@ -4,15 +4,30 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_CalledFactory: XCTestCase {
-  func testVariableDeclaration() throws {
+  func testInternalVariableDeclaration() throws {
     let variablePrefix = "functionName"
-
-    let result = try CalledFactory().variableDeclaration(variablePrefix: variablePrefix)
-
+    
+    let result = try CalledFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: false)
+    
     assertBuildResult(
       result,
       """
       var functionNameCalled: Bool {
+          return functionNameCallsCount > 0
+      }
+      """
+    )
+  }
+  
+  func testPublicVariableDeclaration() throws {
+    let variablePrefix = "functionName"
+    
+    let result = try CalledFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: true)
+    
+    assertBuildResult(
+      result,
+      """
+      public var functionNameCalled: Bool {
           return functionNameCallsCount > 0
       }
       """

--- a/Tests/SpyableMacroTests/Factories/UT_CallsCountFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_CallsCountFactory.swift
@@ -4,16 +4,29 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_CallsCountFactory: XCTestCase {
-  func testVariableDeclaration() throws {
+  func testInternalVariableDeclaration() throws {
     let variablePrefix = "functionName"
 
-    let result = try CallsCountFactory().variableDeclaration(variablePrefix: variablePrefix)
+    let result = try CallsCountFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: false)
 
     assertBuildResult(
       result,
       """
       var functionNameCallsCount = 0
       """
+    )
+  }
+    
+  func testPublicVariableDeclaration() throws {
+    let variablePrefix = "functionName"
+    
+    let result = try CallsCountFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: true)
+    
+    assertBuildResult(
+      result,
+        """
+        public var functionNameCallsCount = 0
+        """
     )
   }
 

--- a/Tests/SpyableMacroTests/Factories/UT_ClosureFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ClosureFactory.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_ClosureFactory: XCTestCase {
-  func testVariableDeclaration() throws {
+  func testInternalVariableDeclaration() throws {
     let variablePrefix = "foo"
 
     let protocolFunctionDeclaration = try FunctionDeclSyntax(
@@ -15,6 +15,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 
@@ -25,6 +26,30 @@ final class UT_ClosureFactory: XCTestCase {
       """
     )
   }
+  
+  func testPublicVariableDeclaration() throws {
+    let variablePrefix = "foo"
+
+    let protocolFunctionDeclaration = try FunctionDeclSyntax(
+      """
+      func foo()
+      """
+    ) {}
+
+    let result = try ClosureFactory().variableDeclaration(
+      variablePrefix: variablePrefix,
+      isPublic: true,
+      functionSignature: protocolFunctionDeclaration.signature
+    )
+
+    assertBuildResult(
+      result,
+      """
+      public var fooClosure: (() -> Void)?
+      """
+    )
+  }
+
 
   func testVariableDeclarationArguments() throws {
     let variablePrefix = "foo"
@@ -37,6 +62,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 
@@ -59,6 +85,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 
@@ -81,6 +108,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 
@@ -103,6 +131,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 
@@ -130,6 +159,7 @@ final class UT_ClosureFactory: XCTestCase {
 
     let result = try ClosureFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionSignature: protocolFunctionDeclaration.signature
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_FunctionImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_FunctionImplementationFactory.swift
@@ -4,7 +4,7 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_FunctionImplementationFactory: XCTestCase {
-  func testDeclaration() throws {
+  func testInternalDeclaration() throws {
     let variablePrefix = "functionName"
 
     let protocolFunctionDeclaration = try FunctionDeclSyntax(
@@ -13,6 +13,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
 
     let result = FunctionImplementationFactory().declaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )
 
@@ -20,6 +21,30 @@ final class UT_FunctionImplementationFactory: XCTestCase {
       result,
       """
       func foo() {
+          functionNameCallsCount += 1
+          functionNameClosure?()
+      }
+      """
+    )
+  }
+  
+  func testPublicDeclaration() throws {
+    let variablePrefix = "functionName"
+
+    let protocolFunctionDeclaration = try FunctionDeclSyntax(
+      "func foo()"
+    ) {}
+
+    let result = FunctionImplementationFactory().declaration(
+      variablePrefix: variablePrefix,
+      isPublic: true,
+      protocolFunctionDeclaration: protocolFunctionDeclaration
+    )
+
+    assertBuildResult(
+      result,
+      """
+      public func foo() {
           functionNameCallsCount += 1
           functionNameClosure?()
       }
@@ -36,6 +61,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
 
     let result = FunctionImplementationFactory().declaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )
 
@@ -61,6 +87,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
 
     let result = FunctionImplementationFactory().declaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )
 
@@ -88,6 +115,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
 
     let result = FunctionImplementationFactory().declaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )
 
@@ -120,6 +148,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
 
     let result = FunctionImplementationFactory().declaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
@@ -6,14 +6,15 @@ import XCTest
 final class UT_ReceivedArgumentsFactory: XCTestCase {
   // MARK: - Variable Declaration
 
-  func testVariableDeclarationSingleArgument() throws {
+  func testInternalVariableDeclarationSingleArgument() throws {
     let variablePrefix = "foo"
     let functionDeclaration = try FunctionDeclSyntax(
       "func foo(bar: String)"
     ) {}
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
-      variablePrefix: variablePrefix,
+        variablePrefix: variablePrefix,
+        isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -25,7 +26,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
     )
   }
 
-  func testVariableDeclarationSingleOptionalArgument() throws {
+  func testPublicVariableDeclarationSingleOptionalArgument() throws {
     let variablePrefix = "foo_name"
     let functionDeclaration = try FunctionDeclSyntax(
       "func foo(_ price: Decimal?)"
@@ -33,13 +34,14 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: true,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
     assertBuildResult(
       result,
       """
-      var foo_nameReceivedPrice: Decimal?
+      public var foo_nameReceivedPrice: Decimal?
       """
     )
   }
@@ -52,6 +54,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -71,6 +74,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -90,6 +94,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -109,6 +114,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -128,6 +134,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -147,6 +154,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -166,6 +174,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -185,6 +194,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -204,6 +214,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
@@ -6,7 +6,7 @@ import XCTest
 final class UT_ReceivedInvocationsFactory: XCTestCase {
   // MARK: - Variable Declaration
 
-  func testVariableDeclarationSingleArgument() throws {
+  func testInternalVariableDeclarationSingleArgument() throws {
     let variablePrefix = "foo"
     let functionDeclaration = try FunctionDeclSyntax(
       "func foo(bar: String?)"
@@ -14,6 +14,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -21,6 +22,26 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
       result,
       """
       var fooReceivedInvocations: [String?] = []
+      """
+    )
+  }
+  
+  func testPublicVariableDeclarationSingleArgument() throws {
+    let variablePrefix = "foo"
+    let functionDeclaration = try FunctionDeclSyntax(
+      "func foo(bar: String?)"
+    ) {}
+
+    let result = try ReceivedInvocationsFactory().variableDeclaration(
+      variablePrefix: variablePrefix,
+      isPublic: true,
+      parameterList: functionDeclaration.signature.parameterClause.parameters
+    )
+
+    assertBuildResult(
+      result,
+      """
+      public var fooReceivedInvocations: [String?] = []
       """
     )
   }
@@ -33,6 +54,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -52,6 +74,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -71,6 +94,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -90,6 +114,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -109,6 +134,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -128,6 +154,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -147,6 +174,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 
@@ -166,6 +194,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       parameterList: functionDeclaration.signature.parameterClause.parameters
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
@@ -4,12 +4,13 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_ReturnValueFactory: XCTestCase {
-  func testVariableDeclaration() throws {
+  func testInternalVariableDeclaration() throws {
     let variablePrefix = "function_name"
     let functionReturnType = TypeSyntax("(text: String, count: UInt)")
 
     let result = try ReturnValueFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionReturnType: functionReturnType
     )
 
@@ -20,6 +21,24 @@ final class UT_ReturnValueFactory: XCTestCase {
       """
     )
   }
+  
+  func testPublicVariableDeclaration() throws {
+    let variablePrefix = "function_name"
+    let functionReturnType = TypeSyntax("(text: String, count: UInt)")
+    
+    let result = try ReturnValueFactory().variableDeclaration(
+      variablePrefix: variablePrefix,
+      isPublic: true,
+      functionReturnType: functionReturnType
+    )
+    
+    assertBuildResult(
+      result,
+        """
+        public var function_nameReturnValue: (text: String, count: UInt)!
+        """
+    )
+  }
 
   func testVariableDeclarationOptionType() throws {
     let variablePrefix = "functionName"
@@ -27,6 +46,7 @@ final class UT_ReturnValueFactory: XCTestCase {
 
     let result = try ReturnValueFactory().variableDeclaration(
       variablePrefix: variablePrefix,
+      isPublic: false,
       functionReturnType: functionReturnType
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -273,6 +273,8 @@ final class UT_SpyFactory: XCTestCase {
       result,
         """
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public var data: Data?
         }
         """

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -235,7 +235,7 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
-  func testDeclarationOptionalVariable() throws {
+  func testInternalDeclarationOptionalVariable() throws {
     let declaration = DeclSyntax(
       """
       protocol ServiceProtocol {
@@ -254,6 +254,28 @@ final class UT_SpyFactory: XCTestCase {
           var data: Data?
       }
       """
+    )
+  }
+    
+  func testPublicDeclarationOptionalVariable() throws {
+    let declaration = DeclSyntax(
+        """
+        public protocol ServiceProtocol {
+            var data: Data? { get set }
+        }
+        """
+    )
+    let protocolDeclaration = try XCTUnwrap(ProtocolDeclSyntax(declaration))
+    
+    let result = try SpyFactory().classDeclaration(for: protocolDeclaration)
+    
+    assertBuildResult(
+      result,
+        """
+        public class ServiceProtocolSpy: ServiceProtocol {
+            public var data: Data?
+        }
+        """
     )
   }
 

--- a/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
@@ -4,16 +4,29 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_ThrowableErrorFactory: XCTestCase {
-  func testVariableDeclaration() throws {
+  func testInternalVariableDeclaration() throws {
     let variablePrefix = "functionName"
 
-    let result = try ThrowableErrorFactory().variableDeclaration(variablePrefix: variablePrefix)
+    let result = try ThrowableErrorFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: false)
 
     assertBuildResult(
       result,
       """
       var functionNameThrowableError: (any Error)?
       """
+    )
+  }
+  
+  func testPublicVariableDeclaration() throws {
+    let variablePrefix = "functionName"
+    
+    let result = try ThrowableErrorFactory().variableDeclaration(variablePrefix: variablePrefix, isPublic: true)
+    
+    assertBuildResult(
+      result,
+        """
+        public var functionNameThrowableError: (any Error)?
+        """
     )
   }
 

--- a/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
@@ -4,13 +4,14 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_VariablesImplementationFactory: XCTestCase {
-  func testVariablesDeclarations() throws {
+  func testInternalVariablesDeclarations() throws {
     let declaration = DeclSyntax("var point: (x: Int, y: Int?, (Int, Int)) { get }")
 
     let protocolVariableDeclaration = try XCTUnwrap(VariableDeclSyntax(declaration))
 
     let result = try VariablesImplementationFactory().variablesDeclarations(
-      protocolVariableDeclaration: protocolVariableDeclaration
+      protocolVariableDeclaration: protocolVariableDeclaration,
+      isPublic: false
     )
 
     assertBuildResult(
@@ -28,6 +29,32 @@ final class UT_VariablesImplementationFactory: XCTestCase {
       """
     )
   }
+  
+  func testPublicVariablesDeclarations() throws {
+    let declaration = DeclSyntax("var point: (x: Int, y: Int?, (Int, Int)) { get }")
+
+    let protocolVariableDeclaration = try XCTUnwrap(VariableDeclSyntax(declaration))
+
+    let result = try VariablesImplementationFactory().variablesDeclarations(
+      protocolVariableDeclaration: protocolVariableDeclaration,
+      isPublic: true
+    )
+
+    assertBuildResult(
+      result,
+      """
+      public var point: (x: Int, y: Int?, (Int, Int)) {
+          get {
+              underlyingPoint
+          }
+          set {
+              underlyingPoint = newValue
+          }
+      }
+      public var underlyingPoint: ((x: Int, y: Int?, (Int, Int)))!
+      """
+    )
+  }
 
   func testVariablesDeclarationsOptional() throws {
     let declaration = DeclSyntax("var foo: String? { get }")
@@ -35,7 +62,8 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     let protocolVariableDeclaration = try XCTUnwrap(VariableDeclSyntax(declaration))
 
     let result = try VariablesImplementationFactory().variablesDeclarations(
-      protocolVariableDeclaration: protocolVariableDeclaration
+      protocolVariableDeclaration: protocolVariableDeclaration,
+      isPublic: false
     )
 
     assertBuildResult(
@@ -52,7 +80,8 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     let protocolVariableDeclaration = try XCTUnwrap(VariableDeclSyntax(declaration))
 
     let result = try VariablesImplementationFactory().variablesDeclarations(
-      protocolVariableDeclaration: protocolVariableDeclaration
+      protocolVariableDeclaration: protocolVariableDeclaration,
+      isPublic: false
     )
 
     assertBuildResult(
@@ -78,7 +107,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
 
     XCTAssertThrowsError(
       try VariablesImplementationFactory().variablesDeclarations(
-        protocolVariableDeclaration: protocolVariableDeclaration)
+        protocolVariableDeclaration: protocolVariableDeclaration, isPublic: false)
     ) { error in
       XCTAssertEqual(
         error as! SpyableDiagnostic, SpyableDiagnostic.variableDeclInProtocolWithNotSingleBinding)
@@ -92,7 +121,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
 
     XCTAssertThrowsError(
       try VariablesImplementationFactory().variablesDeclarations(
-        protocolVariableDeclaration: protocolVariableDeclaration)
+        protocolVariableDeclaration: protocolVariableDeclaration, isPublic: false)
     ) { error in
       XCTAssertEqual(
         error as! SpyableDiagnostic,

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -5,10 +5,10 @@ import XCTest
 @testable import SpyableMacro
 
 final class UT_SpyableMacro: XCTestCase {
-  private let sut = ["Spyable": SpyableMacro.self]
-
-  func testMacro() {
-    let protocolDeclaration = """
+    private let sut = ["Spyable": SpyableMacro.self]
+    
+    func testPublicMacro() {
+        let protocolDeclaration = """
       public protocol ServiceProtocol {
           var name: String {
               get
@@ -28,24 +28,24 @@ final class UT_SpyableMacro: XCTestCase {
               get
               set
           }
-
+      
           mutating func logout()
           func initialize(name: String, secondName: String?)
           func fetchConfig() async throws -> [String: String]
           func fetchData(_ name: (String, count: Int)) async -> (() -> Void)
       }
       """
-
-    assertMacroExpansion(
+        
+        assertMacroExpansion(
       """
       @Spyable
       \(protocolDeclaration)
       """,
       expandedSource: """
-
+        
         \(protocolDeclaration)
-
-        class ServiceProtocolSpy: ServiceProtocol {
+        
+        public class ServiceProtocolSpy: ServiceProtocol {
             var name: String {
                 get {
                     underlyingName
@@ -136,31 +136,163 @@ final class UT_SpyableMacro: XCTestCase {
         }
         """,
       macros: sut
-    )
-  }
-
-  func testMacroWithFlag() {
-    let protocolDeclaration = """
+        )
+    }
+    
+    func testInternalMacro() {
+        let protocolDeclaration = """
+        protocol ServiceProtocol {
+            var name: String {
+                get
+            }
+            var anyProtocol: any Codable {
+                get
+                set
+            }
+            var secondName: String? {
+                get
+            }
+            var added: () -> Void {
+                get
+                set
+            }
+            var removed: (() -> Void)? {
+                get
+                set
+            }
+        
+            mutating func logout()
+            func initialize(name: String, secondName: String?)
+            func fetchConfig() async throws -> [String: String]
+            func fetchData(_ name: (String, count: Int)) async -> (() -> Void)
+        }
+        """
+        
+        assertMacroExpansion(
+        """
+        @Spyable
+        \(protocolDeclaration)
+        """,
+        expandedSource: """
+          
+          \(protocolDeclaration)
+          
+          class ServiceProtocolSpy: ServiceProtocol {
+              var name: String {
+                  get {
+                      underlyingName
+                  }
+                  set {
+                      underlyingName = newValue
+                  }
+              }
+              var underlyingName: (String)!
+              var anyProtocol: any Codable {
+                  get {
+                      underlyingAnyProtocol
+                  }
+                  set {
+                      underlyingAnyProtocol = newValue
+                  }
+              }
+              var underlyingAnyProtocol: (any Codable)!
+                  var secondName: String?
+              var added: () -> Void {
+                  get {
+                      underlyingAdded
+                  }
+                  set {
+                      underlyingAdded = newValue
+                  }
+              }
+              var underlyingAdded: (() -> Void)!
+                  var removed: (() -> Void)?
+              var logoutCallsCount = 0
+              var logoutCalled: Bool {
+                  return logoutCallsCount > 0
+              }
+              var logoutClosure: (() -> Void)?
+              func logout() {
+                  logoutCallsCount += 1
+                  logoutClosure?()
+              }
+              var initializeNameSecondNameCallsCount = 0
+              var initializeNameSecondNameCalled: Bool {
+                  return initializeNameSecondNameCallsCount > 0
+              }
+              var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
+              var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
+              var initializeNameSecondNameClosure: ((String, String?) -> Void)?
+                  func initialize(name: String, secondName: String?) {
+                  initializeNameSecondNameCallsCount += 1
+                  initializeNameSecondNameReceivedArguments = (name, secondName)
+                  initializeNameSecondNameReceivedInvocations.append((name, secondName))
+                  initializeNameSecondNameClosure?(name, secondName)
+              }
+              var fetchConfigCallsCount = 0
+              var fetchConfigCalled: Bool {
+                  return fetchConfigCallsCount > 0
+              }
+              var fetchConfigThrowableError: (any Error)?
+              var fetchConfigReturnValue: [String: String]!
+              var fetchConfigClosure: (() async throws -> [String: String])?
+                  func fetchConfig() async throws -> [String: String] {
+                  fetchConfigCallsCount += 1
+                  if let fetchConfigThrowableError {
+                      throw fetchConfigThrowableError
+                  }
+                  if fetchConfigClosure != nil {
+                      return try await fetchConfigClosure!()
+                  } else {
+                      return fetchConfigReturnValue
+                  }
+              }
+              var fetchDataCallsCount = 0
+              var fetchDataCalled: Bool {
+                  return fetchDataCallsCount > 0
+              }
+              var fetchDataReceivedName: (String, count: Int)?
+              var fetchDataReceivedInvocations: [(String, count: Int)] = []
+              var fetchDataReturnValue: (() -> Void)!
+              var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
+                  func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
+                  fetchDataCallsCount += 1
+                  fetchDataReceivedName = (name)
+                  fetchDataReceivedInvocations.append((name))
+                  if fetchDataClosure != nil {
+                      return await fetchDataClosure!(name)
+                  } else {
+                      return fetchDataReturnValue
+                  }
+              }
+          }
+          """,
+        macros: sut
+        )
+    }
+    
+    func testPublicMacroWithFlag() {
+        let protocolDeclaration = """
       public protocol ServiceProtocol {
           var variable: Bool? { get set }
       }
       """
-    assertMacroExpansion(
+        assertMacroExpansion(
       """
       @Spyable(behindPreprocessorFlag: "CUSTOM")
       \(protocolDeclaration)
       """,
       expandedSource: """
-
+        
         \(protocolDeclaration)
-
+        
         #if CUSTOM
-        class ServiceProtocolSpy: ServiceProtocol {
+        public class ServiceProtocolSpy: ServiceProtocol {
             var variable: Bool?
         }
         #endif
         """,
       macros: sut
-    )
-  }
+        )
+    }
 }

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -46,7 +46,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
         
         public class ServiceProtocolSpy: ServiceProtocol {
-            var name: String {
+            public var name: String {
                 get {
                     underlyingName
                 }
@@ -54,8 +54,8 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingName = newValue
                 }
             }
-            var underlyingName: (String)!
-            var anyProtocol: any Codable {
+            public var underlyingName: (String)!
+            public var anyProtocol: any Codable {
                 get {
                     underlyingAnyProtocol
                 }
@@ -63,9 +63,9 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingAnyProtocol = newValue
                 }
             }
-            var underlyingAnyProtocol: (any Codable)!
-                var secondName: String?
-            var added: () -> Void {
+            public var underlyingAnyProtocol: (any Codable)!
+            public var secondName: String?
+            public var added: () -> Void {
                 get {
                     underlyingAdded
                 }
@@ -73,38 +73,38 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingAdded = newValue
                 }
             }
-            var underlyingAdded: (() -> Void)!
-                var removed: (() -> Void)?
-            var logoutCallsCount = 0
-            var logoutCalled: Bool {
+            public var underlyingAdded: (() -> Void)!
+            public var removed: (() -> Void)?
+            public var logoutCallsCount = 0
+            public var logoutCalled: Bool {
                 return logoutCallsCount > 0
             }
-            var logoutClosure: (() -> Void)?
-            func logout() {
+            public var logoutClosure: (() -> Void)?
+            public func logout() {
                 logoutCallsCount += 1
                 logoutClosure?()
             }
-            var initializeNameSecondNameCallsCount = 0
-            var initializeNameSecondNameCalled: Bool {
+            public var initializeNameSecondNameCallsCount = 0
+            public var initializeNameSecondNameCalled: Bool {
                 return initializeNameSecondNameCallsCount > 0
             }
-            var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
-            var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
-            var initializeNameSecondNameClosure: ((String, String?) -> Void)?
-                func initialize(name: String, secondName: String?) {
+            public var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
+            public var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
+            public var initializeNameSecondNameClosure: ((String, String?) -> Void)?
+            public func initialize(name: String, secondName: String?) {
                 initializeNameSecondNameCallsCount += 1
                 initializeNameSecondNameReceivedArguments = (name, secondName)
                 initializeNameSecondNameReceivedInvocations.append((name, secondName))
                 initializeNameSecondNameClosure?(name, secondName)
             }
-            var fetchConfigCallsCount = 0
-            var fetchConfigCalled: Bool {
+            public var fetchConfigCallsCount = 0
+            public var fetchConfigCalled: Bool {
                 return fetchConfigCallsCount > 0
             }
-            var fetchConfigThrowableError: (any Error)?
-            var fetchConfigReturnValue: [String: String]!
-            var fetchConfigClosure: (() async throws -> [String: String])?
-                func fetchConfig() async throws -> [String: String] {
+            public var fetchConfigThrowableError: (any Error)?
+            public var fetchConfigReturnValue: [String: String]!
+            public var fetchConfigClosure: (() async throws -> [String: String])?
+            public func fetchConfig() async throws -> [String: String] {
                 fetchConfigCallsCount += 1
                 if let fetchConfigThrowableError {
                     throw fetchConfigThrowableError
@@ -115,15 +115,15 @@ final class UT_SpyableMacro: XCTestCase {
                     return fetchConfigReturnValue
                 }
             }
-            var fetchDataCallsCount = 0
-            var fetchDataCalled: Bool {
+            public var fetchDataCallsCount = 0
+            public var fetchDataCalled: Bool {
                 return fetchDataCallsCount > 0
             }
-            var fetchDataReceivedName: (String, count: Int)?
-            var fetchDataReceivedInvocations: [(String, count: Int)] = []
-            var fetchDataReturnValue: (() -> Void)!
-            var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
-                func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
+            public var fetchDataReceivedName: (String, count: Int)?
+            public var fetchDataReceivedInvocations: [(String, count: Int)] = []
+            public var fetchDataReturnValue: (() -> Void)!
+            public var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
+            public func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
                 fetchDataCallsCount += 1
                 fetchDataReceivedName = (name)
                 fetchDataReceivedInvocations.append((name))
@@ -196,7 +196,7 @@ final class UT_SpyableMacro: XCTestCase {
                   }
               }
               var underlyingAnyProtocol: (any Codable)!
-                  var secondName: String?
+              var secondName: String?
               var added: () -> Void {
                   get {
                       underlyingAdded
@@ -206,7 +206,7 @@ final class UT_SpyableMacro: XCTestCase {
                   }
               }
               var underlyingAdded: (() -> Void)!
-                  var removed: (() -> Void)?
+              var removed: (() -> Void)?
               var logoutCallsCount = 0
               var logoutCalled: Bool {
                   return logoutCallsCount > 0
@@ -223,7 +223,7 @@ final class UT_SpyableMacro: XCTestCase {
               var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
               var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
               var initializeNameSecondNameClosure: ((String, String?) -> Void)?
-                  func initialize(name: String, secondName: String?) {
+              func initialize(name: String, secondName: String?) {
                   initializeNameSecondNameCallsCount += 1
                   initializeNameSecondNameReceivedArguments = (name, secondName)
                   initializeNameSecondNameReceivedInvocations.append((name, secondName))
@@ -236,7 +236,7 @@ final class UT_SpyableMacro: XCTestCase {
               var fetchConfigThrowableError: (any Error)?
               var fetchConfigReturnValue: [String: String]!
               var fetchConfigClosure: (() async throws -> [String: String])?
-                  func fetchConfig() async throws -> [String: String] {
+              func fetchConfig() async throws -> [String: String] {
                   fetchConfigCallsCount += 1
                   if let fetchConfigThrowableError {
                       throw fetchConfigThrowableError
@@ -255,7 +255,7 @@ final class UT_SpyableMacro: XCTestCase {
               var fetchDataReceivedInvocations: [(String, count: Int)] = []
               var fetchDataReturnValue: (() -> Void)!
               var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
-                  func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
+              func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
                   fetchDataCallsCount += 1
                   fetchDataReceivedName = (name)
                   fetchDataReceivedInvocations.append((name))
@@ -288,7 +288,7 @@ final class UT_SpyableMacro: XCTestCase {
         
         #if CUSTOM
         public class ServiceProtocolSpy: ServiceProtocol {
-            var variable: Bool?
+            public var variable: Bool?
         }
         #endif
         """,

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -46,6 +46,8 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
         
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public var name: String {
                 get {
                     underlyingName
@@ -288,6 +290,8 @@ final class UT_SpyableMacro: XCTestCase {
         
         #if CUSTOM
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public var variable: Bool?
         }
         #endif


### PR DESCRIPTION
This fixes https://github.com/Matejkob/swift-spyable/issues/72 .

This PR checks if the protocol is declared as public and if it does, marks all the methods and the properties as public in order to be visible from outside of the declaring module. This comes in handy when using modules that use the `@Spyable` macro and want to use those spies in another modules as well.