### PR TITLE
Inherit protocol modifiers

### DIFF
--- a/Sources/SpyableMacro/Extensions/VariableDeclSyntax+Applying.swift
+++ b/Sources/SpyableMacro/Extensions/VariableDeclSyntax+Applying.swift
@@ -1,0 +1,9 @@
+import SwiftSyntax
+
+extension VariableDeclSyntax {
+  func applying(modifiers: DeclModifierListSyntax) -> VariableDeclSyntax {
+    var copy = self
+    copy.modifiers = modifiers
+    return copy
+  }
+}

--- a/Sources/SpyableMacro/Factories/CalledFactory.swift
+++ b/Sources/SpyableMacro/Factories/CalledFactory.swift
@@ -28,14 +28,13 @@ struct CalledFactory {
   func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
     -> VariableDeclSyntax
   {
-    var decl = try VariableDeclSyntax(
+    try VariableDeclSyntax(
       """
       var \(raw: variablePrefix)Called: Bool {
           return \(raw: variablePrefix)CallsCount > 0
       }
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 }

--- a/Sources/SpyableMacro/Factories/CalledFactory.swift
+++ b/Sources/SpyableMacro/Factories/CalledFactory.swift
@@ -25,13 +25,17 @@ import SwiftSyntaxBuilder
 /// ```
 /// and an argument `variablePrefix` equal to `foo`.
 struct CalledFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
-    try VariableDeclSyntax(
+  func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
+    -> VariableDeclSyntax
+  {
+    var decl = try VariableDeclSyntax(
       """
       var \(raw: variablePrefix)Called: Bool {
           return \(raw: variablePrefix)CallsCount > 0
       }
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 }

--- a/Sources/SpyableMacro/Factories/CallsCountFactory.swift
+++ b/Sources/SpyableMacro/Factories/CallsCountFactory.swift
@@ -21,12 +21,16 @@ import SwiftSyntaxBuilder
 /// ```
 /// and an argument `variablePrefix` equal to `foo`.
 struct CallsCountFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
-    try VariableDeclSyntax(
+  func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
+    -> VariableDeclSyntax
+  {
+    var decl = try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)) = 0
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   func incrementVariableExpression(variablePrefix: String) -> ExprSyntax {

--- a/Sources/SpyableMacro/Factories/CallsCountFactory.swift
+++ b/Sources/SpyableMacro/Factories/CallsCountFactory.swift
@@ -24,13 +24,12 @@ struct CallsCountFactory {
   func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
     -> VariableDeclSyntax
   {
-    var decl = try VariableDeclSyntax(
+    try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)) = 0
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   func incrementVariableExpression(variablePrefix: String) -> ExprSyntax {

--- a/Sources/SpyableMacro/Factories/ClosureFactory.swift
+++ b/Sources/SpyableMacro/Factories/ClosureFactory.swift
@@ -55,13 +55,12 @@ struct ClosureFactory {
       )
     }
 
-    var decl = try VariableDeclSyntax(
+    return try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)): (\(elements))?
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   func callExpression(

--- a/Sources/SpyableMacro/Factories/ClosureFactory.swift
+++ b/Sources/SpyableMacro/Factories/ClosureFactory.swift
@@ -29,6 +29,7 @@ import SwiftSyntaxBuilder
 ///         interacts correctly with the function.
 struct ClosureFactory {
   func variableDeclaration(
+    modifiers: DeclModifierListSyntax,
     variablePrefix: String,
     functionSignature: FunctionSignatureSyntax
   ) throws -> VariableDeclSyntax {
@@ -54,11 +55,13 @@ struct ClosureFactory {
       )
     }
 
-    return try VariableDeclSyntax(
+    var decl = try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)): (\(elements))?
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   func callExpression(

--- a/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
@@ -64,12 +64,20 @@ struct FunctionImplementationFactory {
   private let returnValueFactory = ReturnValueFactory()
 
   func declaration(
+    modifiers: DeclModifierListSyntax,
     variablePrefix: String,
     protocolFunctionDeclaration: FunctionDeclSyntax
   ) -> FunctionDeclSyntax {
     var spyFunctionDeclaration = protocolFunctionDeclaration
 
-    spyFunctionDeclaration.modifiers = protocolFunctionDeclaration.modifiers.removingMutatingKeyword
+    spyFunctionDeclaration.modifiers = DeclModifierListSyntax {
+      for protoModifier in modifiers {
+        protoModifier
+      }
+      for functionModifier in protocolFunctionDeclaration.modifiers.removingMutatingKeyword {
+        functionModifier
+      }
+    }
 
     spyFunctionDeclaration.body = CodeBlockSyntax {
       let parameterList = protocolFunctionDeclaration.signature.parameterClause.parameters

--- a/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
@@ -47,13 +47,12 @@ struct ReceivedArgumentsFactory {
     )
     let type = variableType(parameterList: parameterList)
 
-    var decl = try VariableDeclSyntax(
+    return try VariableDeclSyntax(
       """
       var \(identifier): \(type)
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   private func variableType(parameterList: FunctionParameterListSyntax) -> TypeSyntaxProtocol {

--- a/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedArgumentsFactory.swift
@@ -37,6 +37,7 @@ import SwiftSyntaxBuilder
 /// and an argument `variablePrefix` equal to `bar`.
 struct ReceivedArgumentsFactory {
   func variableDeclaration(
+    modifiers: DeclModifierListSyntax,
     variablePrefix: String,
     parameterList: FunctionParameterListSyntax
   ) throws -> VariableDeclSyntax {
@@ -46,11 +47,13 @@ struct ReceivedArgumentsFactory {
     )
     let type = variableType(parameterList: parameterList)
 
-    return try VariableDeclSyntax(
+    var decl = try VariableDeclSyntax(
       """
       var \(identifier): \(type)
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   private func variableType(parameterList: FunctionParameterListSyntax) -> TypeSyntaxProtocol {

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -49,13 +49,12 @@ struct ReceivedInvocationsFactory {
     let identifier = variableIdentifier(variablePrefix: variablePrefix)
     let elementType = arrayElementType(parameterList: parameterList)
 
-    var decl = try VariableDeclSyntax(
+    return try VariableDeclSyntax(
       """
       var \(identifier): [\(elementType)] = []
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   private func arrayElementType(parameterList: FunctionParameterListSyntax) -> TypeSyntaxProtocol {

--- a/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReceivedInvocationsFactory.swift
@@ -42,17 +42,20 @@ import SwiftSyntaxBuilder
 ///         about the arguments in the last invocation, use `ReceivedArgumentsFactory`.
 struct ReceivedInvocationsFactory {
   func variableDeclaration(
+    modifiers: DeclModifierListSyntax,
     variablePrefix: String,
     parameterList: FunctionParameterListSyntax
   ) throws -> VariableDeclSyntax {
     let identifier = variableIdentifier(variablePrefix: variablePrefix)
     let elementType = arrayElementType(parameterList: parameterList)
 
-    return try VariableDeclSyntax(
+    var decl = try VariableDeclSyntax(
       """
       var \(identifier): [\(elementType)] = []
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   private func arrayElementType(parameterList: FunctionParameterListSyntax) -> TypeSyntaxProtocol {

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -39,6 +39,7 @@ import SwiftSyntaxBuilder
 ///         correctly to different returned values.
 struct ReturnValueFactory {
   func variableDeclaration(
+    modifiers: DeclModifierListSyntax,
     variablePrefix: String,
     functionReturnType: TypeSyntax
   ) throws -> VariableDeclSyntax {
@@ -51,11 +52,13 @@ struct ReturnValueFactory {
         )
       }
 
-    return try VariableDeclSyntax(
+    var decl = try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix))\(typeAnnotation)
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   func returnStatement(variablePrefix: String) -> StmtSyntax {

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -52,13 +52,12 @@ struct ReturnValueFactory {
         )
       }
 
-    var decl = try VariableDeclSyntax(
+    return try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix))\(typeAnnotation)
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   func returnStatement(variablePrefix: String) -> StmtSyntax {

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -118,6 +118,12 @@ struct SpyFactory {
         )
       },
       memberBlockBuilder: {
+        InitializerDeclSyntax(
+          modifiers: modifiers,
+          signature: FunctionSignatureSyntax(parameterClause: .init(parameters: [])),
+          body: CodeBlockSyntax(statements: [])
+        )
+
         for variableDeclaration in variableDeclarations {
           try variablesImplementationFactory.variablesDeclarations(
             modifiers: modifiers,

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -129,37 +129,45 @@ struct SpyFactory {
           let variablePrefix = variablePrefixFactory.text(for: functionDeclaration)
           let parameterList = functionDeclaration.signature.parameterClause.parameters
 
-          try callsCountFactory.variableDeclaration(variablePrefix: variablePrefix)
-          try calledFactory.variableDeclaration(variablePrefix: variablePrefix)
+          try callsCountFactory.variableDeclaration(
+            modifiers: modifiers, variablePrefix: variablePrefix)
+          try calledFactory.variableDeclaration(
+            modifiers: modifiers, variablePrefix: variablePrefix)
 
           if parameterList.supportsParameterTracking {
             try receivedArgumentsFactory.variableDeclaration(
+              modifiers: modifiers,
               variablePrefix: variablePrefix,
               parameterList: parameterList
             )
             try receivedInvocationsFactory.variableDeclaration(
+              modifiers: modifiers,
               variablePrefix: variablePrefix,
               parameterList: parameterList
             )
           }
 
           if functionDeclaration.signature.effectSpecifiers?.throwsSpecifier != nil {
-            try throwableErrorFactory.variableDeclaration(variablePrefix: variablePrefix)
+            try throwableErrorFactory.variableDeclaration(
+              modifiers: modifiers, variablePrefix: variablePrefix)
           }
 
           if let returnType = functionDeclaration.signature.returnClause?.type {
             try returnValueFactory.variableDeclaration(
+              modifiers: modifiers,
               variablePrefix: variablePrefix,
               functionReturnType: returnType
             )
           }
 
           try closureFactory.variableDeclaration(
+            modifiers: modifiers,
             variablePrefix: variablePrefix,
             functionSignature: functionDeclaration.signature
           )
 
           functionImplementationFactory.declaration(
+            modifiers: modifiers,
             variablePrefix: variablePrefix,
             protocolFunctionDeclaration: functionDeclaration
           )

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -108,6 +108,7 @@ struct SpyFactory {
       .compactMap { $0.decl.as(FunctionDeclSyntax.self)?.removingLeadingSpaces }
 
     return try ClassDeclSyntax(
+      modifiers: protocolDeclaration.modifiers,
       name: identifier,
       genericParameterClause: genericParameterClause,
       inheritanceClause: InheritanceClauseSyntax {

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -93,6 +93,7 @@ struct SpyFactory {
   private let functionImplementationFactory = FunctionImplementationFactory()
 
   func classDeclaration(for protocolDeclaration: ProtocolDeclSyntax) throws -> ClassDeclSyntax {
+    let modifiers = protocolDeclaration.modifiers
     let identifier = TokenSyntax.identifier(protocolDeclaration.name.text + "Spy")
 
     let assosciatedtypeDeclarations = protocolDeclaration.memberBlock.members.compactMap {
@@ -108,7 +109,7 @@ struct SpyFactory {
       .compactMap { $0.decl.as(FunctionDeclSyntax.self)?.removingLeadingSpaces }
 
     return try ClassDeclSyntax(
-      modifiers: protocolDeclaration.modifiers,
+      modifiers: modifiers,
       name: identifier,
       genericParameterClause: genericParameterClause,
       inheritanceClause: InheritanceClauseSyntax {
@@ -119,6 +120,7 @@ struct SpyFactory {
       memberBlockBuilder: {
         for variableDeclaration in variableDeclarations {
           try variablesImplementationFactory.variablesDeclarations(
+            modifiers: modifiers,
             protocolVariableDeclaration: variableDeclaration
           )
         }

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -32,13 +32,12 @@ struct ThrowableErrorFactory {
   func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
     -> VariableDeclSyntax
   {
-    var decl = try VariableDeclSyntax(
+    try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)): (any Error)?
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   func throwErrorExpression(variablePrefix: String) -> ExprSyntax {

--- a/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
+++ b/Sources/SpyableMacro/Factories/ThrowableErrorFactory.swift
@@ -29,12 +29,16 @@ import SwiftSyntaxBuilder
 ///         your tests. You can use it to simulate different scenarios and verify that your code handles
 ///         errors correctly.
 struct ThrowableErrorFactory {
-  func variableDeclaration(variablePrefix: String) throws -> VariableDeclSyntax {
-    try VariableDeclSyntax(
+  func variableDeclaration(modifiers: DeclModifierListSyntax, variablePrefix: String) throws
+    -> VariableDeclSyntax
+  {
+    var decl = try VariableDeclSyntax(
       """
       var \(variableIdentifier(variablePrefix: variablePrefix)): (any Error)?
       """
     )
+    decl.modifiers = modifiers
+    return decl
   }
 
   func throwErrorExpression(variablePrefix: String) -> ExprSyntax {

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -47,6 +47,7 @@ struct VariablesImplementationFactory {
 
   @MemberBlockItemListBuilder
   func variablesDeclarations(
+    modifiers: DeclModifierListSyntax,
     protocolVariableDeclaration: VariableDeclSyntax
   ) throws -> MemberBlockItemListSyntax {
     if protocolVariableDeclaration.bindings.count == 1 {
@@ -56,7 +57,7 @@ struct VariablesImplementationFactory {
       if binding.typeAnnotation?.type.is(OptionalTypeSyntax.self) == true {
         accessorRemovalVisitor.visit(protocolVariableDeclaration)
       } else {
-        try protocolVariableDeclarationWithGetterAndSetter(binding: binding)
+        try protocolVariableDeclarationWithGetterAndSetter(modifiers: modifiers, binding: binding)
 
         try underlyingVariableDeclaration(binding: binding)
       }
@@ -67,11 +68,12 @@ struct VariablesImplementationFactory {
   }
 
   private func protocolVariableDeclarationWithGetterAndSetter(
+    modifiers: DeclModifierListSyntax,
     binding: PatternBindingSyntax
   ) throws -> VariableDeclSyntax {
     try VariableDeclSyntax(
       """
-      var \(binding.pattern.trimmed)\(binding.typeAnnotation!.trimmed) {
+      \(modifiers)var \(binding.pattern.trimmed)\(binding.typeAnnotation!.trimmed) {
           get { \(raw: underlyingVariableName(binding: binding)) }
           set { \(raw: underlyingVariableName(binding: binding)) = newValue }
       }

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -110,14 +110,6 @@ struct VariablesImplementationFactory {
   }
 }
 
-extension VariableDeclSyntax {
-  fileprivate func applying(modifiers: DeclModifierListSyntax) -> VariableDeclSyntax {
-    var copy = self
-    copy.modifiers = modifiers
-    return copy
-  }
-}
-
 private class AccessorRemovalVisitor: SyntaxRewriter {
   override func visit(_ node: PatternBindingSyntax) -> PatternBindingSyntax {
     let superResult = super.visit(node)

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -58,7 +58,7 @@ struct VariablesImplementationFactory {
         if let variableDecl = accessorRemovalVisitor.visit(protocolVariableDeclaration).as(
           VariableDeclSyntax.self)
         {
-          variableDecl.settingModifiers(modifiers: modifiers)
+          variableDecl.applying(modifiers: modifiers)
         }
       } else {
         try protocolVariableDeclarationWithGetterAndSetter(modifiers: modifiers, binding: binding)
@@ -75,7 +75,7 @@ struct VariablesImplementationFactory {
     modifiers: DeclModifierListSyntax,
     binding: PatternBindingSyntax
   ) throws -> VariableDeclSyntax {
-    var decl = try VariableDeclSyntax(
+    try VariableDeclSyntax(
       """
       var \(binding.pattern.trimmed)\(binding.typeAnnotation!.trimmed) {
           get { \(raw: underlyingVariableName(binding: binding)) }
@@ -83,21 +83,19 @@ struct VariablesImplementationFactory {
       }
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   private func underlyingVariableDeclaration(
     modifiers: DeclModifierListSyntax,
     binding: PatternBindingListSyntax.Element
   ) throws -> VariableDeclSyntax {
-    var decl = try VariableDeclSyntax(
+    try VariableDeclSyntax(
       """
       var \(raw: underlyingVariableName(binding: binding)): (\(binding.typeAnnotation!.type.trimmed))!
       """
     )
-    decl.modifiers = modifiers
-    return decl
+    .applying(modifiers: modifiers)
   }
 
   private func underlyingVariableName(binding: PatternBindingListSyntax.Element) throws -> String {
@@ -113,7 +111,7 @@ struct VariablesImplementationFactory {
 }
 
 extension VariableDeclSyntax {
-  fileprivate func settingModifiers(modifiers: DeclModifierListSyntax) -> VariableDeclSyntax {
+  fileprivate func applying(modifiers: DeclModifierListSyntax) -> VariableDeclSyntax {
     var copy = self
     copy.modifiers = modifiers
     return copy

--- a/Tests/SpyableMacroTests/Factories/UT_CalledFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_CalledFactory.swift
@@ -10,12 +10,29 @@ final class UT_CalledFactory: XCTestCase {
   func testVariableDeclaration() throws {
     let variablePrefix = "functionName"
 
-    let result = try CalledFactory().variableDeclaration(variablePrefix: variablePrefix)
+    let result = try CalledFactory().variableDeclaration(
+      modifiers: [], variablePrefix: variablePrefix)
 
     assertBuildResult(
       result,
       """
       var functionNameCalled: Bool {
+          return functionNameCallsCount > 0
+      }
+      """
+    )
+  }
+
+  func testVariableDeclarationWithAccess() throws {
+    let variablePrefix = "functionName"
+
+    let result = try CalledFactory().variableDeclaration(
+      modifiers: [.init(name: "public")], variablePrefix: variablePrefix)
+
+    assertBuildResult(
+      result,
+      """
+      public var functionNameCalled: Bool {
           return functionNameCallsCount > 0
       }
       """

--- a/Tests/SpyableMacroTests/Factories/UT_CallsCountFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_CallsCountFactory.swift
@@ -10,12 +10,27 @@ final class UT_CallsCountFactory: XCTestCase {
   func testVariableDeclaration() throws {
     let variablePrefix = "functionName"
 
-    let result = try CallsCountFactory().variableDeclaration(variablePrefix: variablePrefix)
+    let result = try CallsCountFactory().variableDeclaration(
+      modifiers: [], variablePrefix: variablePrefix)
 
     assertBuildResult(
       result,
       """
       var functionNameCallsCount = 0
+      """
+    )
+  }
+
+  func testVariableDeclarationWithAccess() throws {
+    let variablePrefix = "functionName"
+
+    let result = try CallsCountFactory().variableDeclaration(
+      modifiers: [.init(name: "public")], variablePrefix: variablePrefix)
+
+    assertBuildResult(
+      result,
+      """
+      public var functionNameCallsCount = 0
       """
     )
   }

--- a/Tests/SpyableMacroTests/Factories/UT_ClosureFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ClosureFactory.swift
@@ -136,6 +136,7 @@ final class UT_ClosureFactory: XCTestCase {
     let protocolFunctionDeclaration = try FunctionDeclSyntax("\(raw: functionDeclaration)") {}
 
     let result = try ClosureFactory().variableDeclaration(
+      modifiers: [],
       variablePrefix: variablePrefix,
       functionSignature: protocolFunctionDeclaration.signature
     )

--- a/Tests/SpyableMacroTests/Factories/UT_FunctionImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_FunctionImplementationFactory.swift
@@ -20,6 +20,19 @@ final class UT_FunctionImplementationFactory: XCTestCase {
     )
   }
 
+  func testDeclarationAccessModifiers() throws {
+    try assertProtocolFunction(
+      withFunctionDeclaration: "public func foo()",
+      prefixForVariable: "_prefix_",
+      expectingFunctionDeclaration: """
+        public func foo() {
+            _prefix_CallsCount += 1
+            _prefix_Closure?()
+        }
+        """
+    )
+  }
+
   func testDeclarationArguments() throws {
     try assertProtocolFunction(
       withFunctionDeclaration: "func foo(text: String, count: Int)",
@@ -129,6 +142,7 @@ final class UT_FunctionImplementationFactory: XCTestCase {
     let protocolFunctionDeclaration = try FunctionDeclSyntax("\(raw: functionDeclaration)") {}
 
     let result = FunctionImplementationFactory().declaration(
+      modifiers: [],
       variablePrefix: variablePrefix,
       protocolFunctionDeclaration: protocolFunctionDeclaration
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedArgumentsFactory.swift
@@ -15,6 +15,14 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
     )
   }
 
+  func testVariableDeclarationAccess() throws {
+    try assertProtocolFunction(
+      withFunctionDeclaration: "func foo(bar: String)",
+      prefixForVariable: "_prefix_",
+      expectingVariableDeclaration: "var _prefix_ReceivedBar: String?"
+    )
+  }
+
   func testVariableDeclarationSingleOptionalArgument() throws {
     try assertProtocolFunction(
       withFunctionDeclaration: "func foo(_ price: Decimal?)",
@@ -157,6 +165,7 @@ final class UT_ReceivedArgumentsFactory: XCTestCase {
     let protocolFunctionDeclaration = try FunctionDeclSyntax("\(raw: functionDeclaration)") {}
 
     let result = try ReceivedArgumentsFactory().variableDeclaration(
+      modifiers: [],
       variablePrefix: variablePrefix,
       parameterList: protocolFunctionDeclaration.signature.parameterClause.parameters
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
@@ -15,6 +15,15 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
     )
   }
 
+  func testVariableDeclarationWithModifiers() throws {
+    try assertProtocolFunction(
+      withFunctionDeclaration: "func foo(bar: String?)",
+      prefixForVariable: "_prefix_",
+      modifiers: [.init(name: "fileprivate")],
+      expectingVariableDeclaration: "fileprivate var _prefix_ReceivedInvocations: [String?] = []"
+    )
+  }
+
   func testVariableDeclarationSingleArgumentTupleType() throws {
     try assertProtocolFunction(
       withFunctionDeclaration: "func foo(_ tuple: (text: String, (Decimal?, date: Date))?)",
@@ -125,6 +134,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
   private func assertProtocolFunction(
     withFunctionDeclaration functionDeclaration: String,
     prefixForVariable variablePrefix: String,
+    modifiers: DeclModifierListSyntax = [],
     expectingVariableDeclaration expectedDeclaration: String,
     file: StaticString = #file,
     line: UInt = #line
@@ -132,7 +142,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
     let protocolFunctionDeclaration = try FunctionDeclSyntax("\(raw: functionDeclaration)") {}
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
-      modifiers: [],
+      modifiers: modifiers,
       variablePrefix: variablePrefix,
       parameterList: protocolFunctionDeclaration.signature.parameterClause.parameters
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReceivedInvocationsFactory.swift
@@ -132,6 +132,7 @@ final class UT_ReceivedInvocationsFactory: XCTestCase {
     let protocolFunctionDeclaration = try FunctionDeclSyntax("\(raw: functionDeclaration)") {}
 
     let result = try ReceivedInvocationsFactory().variableDeclaration(
+      modifiers: [],
       variablePrefix: variablePrefix,
       parameterList: protocolFunctionDeclaration.signature.parameterClause.parameters
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
@@ -48,6 +48,7 @@ final class UT_ReturnValueFactory: XCTestCase {
     line: UInt = #line
   ) throws {
     let result = try ReturnValueFactory().variableDeclaration(
+      modifiers: [],
       variablePrefix: variablePrefix,
       functionReturnType: functionReturnType
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
@@ -15,6 +15,15 @@ final class UT_ReturnValueFactory: XCTestCase {
     )
   }
 
+  func testVariableDeclarationModifiers() throws {
+    try assert(
+      functionReturnType: "(text: String, count: UInt)",
+      prefixForVariable: "_prefix_",
+      modifiers: [.init(name: "public")],
+      expectingVariableDeclaration: "public var _prefix_ReturnValue: (text: String, count: UInt)!"
+    )
+  }
+
   func testVariableDeclarationOptionType() throws {
     try assert(
       functionReturnType: "String?",
@@ -43,12 +52,13 @@ final class UT_ReturnValueFactory: XCTestCase {
   private func assert(
     functionReturnType: TypeSyntax,
     prefixForVariable variablePrefix: String,
+    modifiers: DeclModifierListSyntax = [],
     expectingVariableDeclaration expectedDeclaration: String,
     file: StaticString = #file,
     line: UInt = #line
   ) throws {
     let result = try ReturnValueFactory().variableDeclaration(
-      modifiers: [],
+      modifiers: modifiers,
       variablePrefix: variablePrefix,
       functionReturnType: functionReturnType
     )

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -234,6 +234,29 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
+  func testDeclarationVariablePublic() throws {
+    try assertProtocol(
+      withDeclaration: """
+        public protocol ServiceProtocol {
+            var data: Data { get }
+        }
+        """,
+      expectingClassDeclaration: """
+        public class ServiceProtocolSpy: ServiceProtocol {
+            public var data: Data {
+                get {
+                    underlyingData
+                }
+                set {
+                    underlyingData = newValue
+                }
+            }
+            var underlyingData: (Data)!
+        }
+        """
+    )
+  }
+
   func testDeclarationOptionalVariable() throws {
     try assertProtocol(
       withDeclaration: """

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -251,7 +251,7 @@ final class UT_SpyFactory: XCTestCase {
                     underlyingData = newValue
                 }
             }
-            var underlyingData: (Data)!
+            public var underlyingData: (Data)!
         }
         """
     )

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -252,31 +252,6 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
-  func testDeclarationVariablePublic() throws {
-    try assertProtocol(
-      withDeclaration: """
-        public protocol ServiceProtocol {
-            var data: Data { get }
-        }
-        """,
-      expectingClassDeclaration: """
-        public class ServiceProtocolSpy: ServiceProtocol {
-            public init() {
-            }
-            public var data: Data {
-                get {
-                    underlyingData
-                }
-                set {
-                    underlyingData = newValue
-                }
-            }
-            public var underlyingData: (Data)!
-        }
-        """
-    )
-  }
-
   func testDeclarationOptionalVariable() throws {
     try assertProtocol(
       withDeclaration: """
@@ -314,6 +289,83 @@ final class UT_SpyFactory: XCTestCase {
                 }
             }
             var underlyingCompletion: (() -> Void)!
+        }
+        """
+    )
+  }
+
+  // MARK: - Access Level
+
+  func testDeclarationPublicAccess() throws {
+    try assertProtocol(
+      withDeclaration: """
+        public protocol ServiceProtocol {
+            var data: Data { get }
+        }
+        """,
+      expectingClassDeclaration: """
+        public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
+            public var data: Data {
+                get {
+                    underlyingData
+                }
+                set {
+                    underlyingData = newValue
+                }
+            }
+            public var underlyingData: (Data)!
+        }
+        """
+    )
+  }
+
+  func testDeclarationPackageAccess() throws {
+    try assertProtocol(
+      withDeclaration: """
+        package protocol ServiceProtocol {
+            var data: Data { get }
+        }
+        """,
+      expectingClassDeclaration: """
+        package class ServiceProtocolSpy: ServiceProtocol {
+            package init() {
+            }
+            package var data: Data {
+                get {
+                    underlyingData
+                }
+                set {
+                    underlyingData = newValue
+                }
+            }
+            package var underlyingData: (Data)!
+        }
+        """
+    )
+  }
+
+  func testDeclarationPrivateAccess() throws {
+    try assertProtocol(
+      withDeclaration: """
+        private protocol ServiceProtocol {
+            var data: Data { get }
+        }
+        """,
+      expectingClassDeclaration: """
+        private class ServiceProtocolSpy: ServiceProtocol {
+            fileprivate init() {
+            }
+            fileprivate var data: Data {
+                get {
+                    underlyingData
+                }
+                set {
+                    underlyingData = newValue
+                }
+            }
+            fileprivate var underlyingData: (Data)!
         }
         """
     )

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -10,6 +10,8 @@ final class UT_SpyFactory: XCTestCase {
       withDeclaration: "protocol Foo {}",
       expectingClassDeclaration: """
         class FooSpy: Foo {
+            init() {
+            }
         }
         """
     )
@@ -24,6 +26,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceSpy: Service {
+            init() {
+            }
             var fetchCallsCount = 0
             var fetchCalled: Bool {
                 return fetchCallsCount > 0
@@ -47,6 +51,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ViewModelProtocolSpy: ViewModelProtocol {
+            init() {
+            }
             var fooTextCountCallsCount = 0
             var fooTextCountCalled: Bool {
                 return fooTextCountCallsCount > 0
@@ -74,6 +80,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ViewModelProtocolSpy: ViewModelProtocol {
+            init() {
+            }
             var fooActionCallsCount = 0
             var fooActionCalled: Bool {
                 return fooActionCallsCount > 0
@@ -101,6 +109,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ViewModelProtocolSpy: ViewModelProtocol {
+            init() {
+            }
             var fooActionCallsCount = 0
             var fooActionCalled: Bool {
                 return fooActionCallsCount > 0
@@ -124,6 +134,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class BarSpy: Bar {
+            init() {
+            }
             var printCallsCount = 0
             var printCalled: Bool {
                 return printCallsCount > 0
@@ -152,6 +164,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var fooTextCountCallsCount = 0
             var fooTextCountCalled: Bool {
                 return fooTextCountCallsCount > 0
@@ -184,6 +198,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var fooCallsCount = 0
             var fooCalled: Bool {
                 return fooCallsCount > 0
@@ -220,6 +236,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var data: Data {
                 get {
                     underlyingData
@@ -243,6 +261,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public var data: Data {
                 get {
                     underlyingData
@@ -266,6 +286,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var data: Data?
         }
         """
@@ -281,6 +303,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var completion: () -> Void {
                 get {
                     underlyingCompletion
@@ -306,6 +330,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class FooSpy<Key: Hashable>: Foo {
+            init() {
+            }
         }
         """
     )
@@ -321,6 +347,8 @@ final class UT_SpyFactory: XCTestCase {
         """,
       expectingClassDeclaration: """
         class FooSpy<Key: Hashable, Value>: Foo {
+            init() {
+            }
         }
         """
     )

--- a/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
@@ -10,12 +10,29 @@ final class UT_ThrowableErrorFactory: XCTestCase {
   func testVariableDeclaration() throws {
     let variablePrefix = "functionName"
 
-    let result = try ThrowableErrorFactory().variableDeclaration(variablePrefix: variablePrefix)
+    let result = try ThrowableErrorFactory().variableDeclaration(
+      modifiers: [], variablePrefix: variablePrefix)
 
     assertBuildResult(
       result,
       """
       var functionNameThrowableError: (any Error)?
+      """
+    )
+  }
+
+  func testVariableDeclarationWithAccess() throws {
+    let variablePrefix = "functionName"
+
+    let result = try ThrowableErrorFactory().variableDeclaration(
+      modifiers: [.init(name: .init(stringLiteral: "public"))],
+      variablePrefix: variablePrefix
+    )
+
+    assertBuildResult(
+      result,
+      """
+      public var functionNameThrowableError: (any Error)?
       """
     )
   }

--- a/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ThrowableErrorFactory.swift
@@ -25,7 +25,7 @@ final class UT_ThrowableErrorFactory: XCTestCase {
     let variablePrefix = "functionName"
 
     let result = try ThrowableErrorFactory().variableDeclaration(
-      modifiers: [.init(name: .init(stringLiteral: "public"))],
+      modifiers: [.init(name: "public")],
       variablePrefix: variablePrefix
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
@@ -51,7 +51,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
   func testVariableDelcarationsWithAccess() throws {
     try assertProtocolVariable(
       withVariableDeclaration: "public var foo: String? { get }",
-      expectingVariableDeclaration: "public var foo: String?"
+      expectingVariableDeclaration: "var foo: String?"
     )
   }
 

--- a/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
@@ -48,11 +48,19 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     )
   }
 
+  func testVariableDelcarationsWithAccess() throws {
+    try assertProtocolVariable(
+      withVariableDeclaration: "public var foo: String? { get }",
+      expectingVariableDeclaration: "public var foo: String?"
+    )
+  }
+
   func testVariablesDeclarationsWithMultiBindings() throws {
     let protocolVariableDeclaration = try VariableDeclSyntax("var foo: String?, bar: Int")
 
     XCTAssertThrowsError(
       try VariablesImplementationFactory().variablesDeclarations(
+        modifiers: [],
         protocolVariableDeclaration: protocolVariableDeclaration
       )
     ) { error in
@@ -68,6 +76,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
 
     XCTAssertThrowsError(
       try VariablesImplementationFactory().variablesDeclarations(
+        modifiers: [],
         protocolVariableDeclaration: protocolVariableDeclaration
       )
     ) { error in
@@ -89,6 +98,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     let protocolVariableDeclaration = try VariableDeclSyntax("\(raw: variableDeclaration)")
 
     let result = try VariablesImplementationFactory().variablesDeclarations(
+      modifiers: [],
       protocolVariableDeclaration: protocolVariableDeclaration
     )
 

--- a/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
@@ -48,10 +48,11 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     )
   }
 
-  func testVariableDelcarationsWithAccess() throws {
+  func testVariableDelcarationsWithModifiers() throws {
     try assertProtocolVariable(
-      withVariableDeclaration: "public var foo: String? { get }",
-      expectingVariableDeclaration: "var foo: String?"
+      withVariableDeclaration: "var foo: String? { get }",
+      modifiers: [.init(name: "fileprivate")],
+      expectingVariableDeclaration: "fileprivate var foo: String?"
     )
   }
 
@@ -91,6 +92,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
 
   private func assertProtocolVariable(
     withVariableDeclaration variableDeclaration: String,
+    modifiers: DeclModifierListSyntax = [],
     expectingVariableDeclaration expectedDeclaration: String,
     file: StaticString = #file,
     line: UInt = #line
@@ -98,7 +100,7 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     let protocolVariableDeclaration = try VariableDeclSyntax("\(raw: variableDeclaration)")
 
     let result = try VariablesImplementationFactory().variablesDeclarations(
-      modifiers: [],
+      modifiers: modifiers,
       protocolVariableDeclaration: protocolVariableDeclaration
     )
 

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -194,32 +194,6 @@ final class UT_SpyableMacro: XCTestCase {
     )
   }
 
-  func testMacroOtherAccessLevel() {
-    let protocolDeclaration = """
-      package protocol ServiceProtocol {
-          var variable: Bool? { get set }
-      }
-      """
-    assertMacroExpansion(
-      """
-      @Spyable
-      \(protocolDeclaration)
-      """,
-      expandedSource: """
-
-        \(protocolDeclaration)
-
-        package class ServiceProtocolSpy: ServiceProtocol {
-            package init() {
-            }
-            package
-            var variable: Bool?
-        }
-        """,
-      macros: sut
-    )
-  }
-
   func testMacroWithCustomFlag() {
     let protocolDeclaration = """
       public protocol ServiceProtocol {
@@ -256,7 +230,7 @@ final class UT_SpyableMacro: XCTestCase {
       """
     assertMacroExpansion(
       """
-      @Spyable(behindPreprocessorFlag: nil)
+      @Spyable
       \(protocolDeclaration)
       """,
       expandedSource: """
@@ -267,31 +241,6 @@ final class UT_SpyableMacro: XCTestCase {
             public init() {
             }
             public
-            var variable: Bool?
-        }
-        """,
-      macros: sut
-    )
-  }
-
-  func testMacroInternal() {
-    let protocolDeclaration = """
-      protocol ServiceProtocol {
-          var variable: Bool? { get set }
-      }
-      """
-    assertMacroExpansion(
-      """
-      @Spyable(behindPreprocessorFlag: nil)
-      \(protocolDeclaration)
-      """,
-      expandedSource: """
-
-        \(protocolDeclaration)
-
-        class ServiceProtocolSpy: ServiceProtocol {
-            init() {
-            }
             var variable: Bool?
         }
         """,

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -58,7 +58,7 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingName = newValue
                 }
             }
-            var underlyingName: (String)!
+            public var underlyingName: (String)!
             public var anyProtocol: any Codable {
                 get {
                     underlyingAnyProtocol
@@ -67,7 +67,8 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingAnyProtocol = newValue
                 }
             }
-            var underlyingAnyProtocol: (any Codable)!
+            public var underlyingAnyProtocol: (any Codable)!
+            public
             var secondName: String?
             public var added: () -> Void {
                 get {
@@ -77,37 +78,40 @@ final class UT_SpyableMacro: XCTestCase {
                     underlyingAdded = newValue
                 }
             }
-            var underlyingAdded: (() -> Void)!
+            public var underlyingAdded: (() -> Void)!
+            public
             var removed: (() -> Void)?
-            var logoutCallsCount = 0
-            var logoutCalled: Bool {
+            public var logoutCallsCount = 0
+            public var logoutCalled: Bool {
                 return logoutCallsCount > 0
             }
-            var logoutClosure: (() -> Void)?
-            func logout() {
+            public var logoutClosure: (() -> Void)?
+            public func logout() {
                 logoutCallsCount += 1
                 logoutClosure?()
             }
-            var initializeNameSecondNameCallsCount = 0
-            var initializeNameSecondNameCalled: Bool {
+            public var initializeNameSecondNameCallsCount = 0
+            public var initializeNameSecondNameCalled: Bool {
                 return initializeNameSecondNameCallsCount > 0
             }
-            var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
-            var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
-            var initializeNameSecondNameClosure: ((String, String?) -> Void)?
+            public var initializeNameSecondNameReceivedArguments: (name: String, secondName: String?)?
+            public var initializeNameSecondNameReceivedInvocations: [(name: String, secondName: String?)] = []
+            public var initializeNameSecondNameClosure: ((String, String?) -> Void)?
+            public
             func initialize(name: String, secondName: String?) {
                 initializeNameSecondNameCallsCount += 1
                 initializeNameSecondNameReceivedArguments = (name, secondName)
                 initializeNameSecondNameReceivedInvocations.append((name, secondName))
                 initializeNameSecondNameClosure?(name, secondName)
             }
-            var fetchConfigCallsCount = 0
-            var fetchConfigCalled: Bool {
+            public var fetchConfigCallsCount = 0
+            public var fetchConfigCalled: Bool {
                 return fetchConfigCallsCount > 0
             }
-            var fetchConfigThrowableError: (any Error)?
-            var fetchConfigReturnValue: [String: String]!
-            var fetchConfigClosure: (() async throws -> [String: String])?
+            public var fetchConfigThrowableError: (any Error)?
+            public var fetchConfigReturnValue: [String: String]!
+            public var fetchConfigClosure: (() async throws -> [String: String])?
+            public
             func fetchConfig() async throws -> [String: String] {
                 fetchConfigCallsCount += 1
                 if let fetchConfigThrowableError {
@@ -119,14 +123,15 @@ final class UT_SpyableMacro: XCTestCase {
                     return fetchConfigReturnValue
                 }
             }
-            var fetchDataCallsCount = 0
-            var fetchDataCalled: Bool {
+            public var fetchDataCallsCount = 0
+            public var fetchDataCalled: Bool {
                 return fetchDataCallsCount > 0
             }
-            var fetchDataReceivedName: (String, count: Int)?
-            var fetchDataReceivedInvocations: [(String, count: Int)] = []
-            var fetchDataReturnValue: (() -> Void)!
-            var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
+            public var fetchDataReceivedName: (String, count: Int)?
+            public var fetchDataReceivedInvocations: [(String, count: Int)] = []
+            public var fetchDataReturnValue: (() -> Void)!
+            public var fetchDataClosure: (((String, count: Int)) async -> (() -> Void))?
+            public
             func fetchData(_ name: (String, count: Int)) async -> (() -> Void) {
                 fetchDataCallsCount += 1
                 fetchDataReceivedName = (name)
@@ -137,42 +142,46 @@ final class UT_SpyableMacro: XCTestCase {
                     return fetchDataReturnValue
                 }
             }
-            var fetchUsernameContextCompletionCallsCount = 0
-            var fetchUsernameContextCompletionCalled: Bool {
+            public var fetchUsernameContextCompletionCallsCount = 0
+            public var fetchUsernameContextCompletionCalled: Bool {
                 return fetchUsernameContextCompletionCallsCount > 0
             }
-            var fetchUsernameContextCompletionReceivedArguments: (context: String, completion: (String) -> Void)?
-            var fetchUsernameContextCompletionReceivedInvocations: [(context: String, completion: (String) -> Void)] = []
-            var fetchUsernameContextCompletionClosure: ((String, @escaping (String) -> Void) -> Void)?
+            public var fetchUsernameContextCompletionReceivedArguments: (context: String, completion: (String) -> Void)?
+            public var fetchUsernameContextCompletionReceivedInvocations: [(context: String, completion: (String) -> Void)] = []
+            public var fetchUsernameContextCompletionClosure: ((String, @escaping (String) -> Void) -> Void)?
+            public
             func fetchUsername(context: String, completion: @escaping (String) -> Void) {
                 fetchUsernameContextCompletionCallsCount += 1
                 fetchUsernameContextCompletionReceivedArguments = (context, completion)
                 fetchUsernameContextCompletionReceivedInvocations.append((context, completion))
                 fetchUsernameContextCompletionClosure?(context, completion)
             }
-            var onTapBackContextActionCallsCount = 0
-            var onTapBackContextActionCalled: Bool {
+            public var onTapBackContextActionCallsCount = 0
+            public var onTapBackContextActionCalled: Bool {
                 return onTapBackContextActionCallsCount > 0
             }
-            var onTapBackContextActionClosure: ((String, () -> Void) -> Void)?
+            public var onTapBackContextActionClosure: ((String, () -> Void) -> Void)?
+            public
             func onTapBack(context: String, action: () -> Void) {
                 onTapBackContextActionCallsCount += 1
                 onTapBackContextActionClosure?(context, action)
             }
-            var onTapNextContextActionCallsCount = 0
-            var onTapNextContextActionCalled: Bool {
+            public var onTapNextContextActionCallsCount = 0
+            public var onTapNextContextActionCalled: Bool {
                 return onTapNextContextActionCallsCount > 0
             }
-            var onTapNextContextActionClosure: ((String, @Sendable () -> Void) -> Void)?
+            public var onTapNextContextActionClosure: ((String, @Sendable () -> Void) -> Void)?
+            public
             func onTapNext(context: String, action: @Sendable () -> Void) {
                 onTapNextContextActionCallsCount += 1
                 onTapNextContextActionClosure?(context, action)
             }
-            var assertCallsCount = 0
-            var assertCalled: Bool {
+            public var assertCallsCount = 0
+            public var assertCalled: Bool {
                 return assertCallsCount > 0
             }
-            var assertClosure: ((@autoclosure () -> String) -> Void)?
+            public var assertClosure: ((@autoclosure () -> String) -> Void)?
+            public
             func assert(_ message: @autoclosure () -> String) {
                 assertCallsCount += 1
                 assertClosure?(message())
@@ -183,7 +192,31 @@ final class UT_SpyableMacro: XCTestCase {
     )
   }
 
-  func testMacroWithFlag() {
+  func testMacroOtherAccessLevel() {
+    let protocolDeclaration = """
+      package protocol ServiceProtocol {
+          var variable: Bool? { get set }
+      }
+      """
+    assertMacroExpansion(
+      """
+      @Spyable
+      \(protocolDeclaration)
+      """,
+      expandedSource: """
+
+        \(protocolDeclaration)
+
+        package class ServiceProtocolSpy: ServiceProtocol {
+            package
+            var variable: Bool?
+        }
+        """,
+      macros: sut
+    )
+  }
+
+  func testMacroWithCustomFlag() {
     let protocolDeclaration = """
       public protocol ServiceProtocol {
           var variable: Bool? { get set }
@@ -200,6 +233,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         #if CUSTOM
         public class ServiceProtocolSpy: ServiceProtocol {
+            public
             var variable: Bool?
         }
         #endif
@@ -224,6 +258,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         public class ServiceProtocolSpy: ServiceProtocol {
+            public
             var variable: Bool?
         }
         """,

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -50,6 +50,8 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public var name: String {
                 get {
                     underlyingName
@@ -208,6 +210,8 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         package class ServiceProtocolSpy: ServiceProtocol {
+            package init() {
+            }
             package
             var variable: Bool?
         }
@@ -233,6 +237,8 @@ final class UT_SpyableMacro: XCTestCase {
 
         #if CUSTOM
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public
             var variable: Bool?
         }
@@ -258,6 +264,8 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         public class ServiceProtocolSpy: ServiceProtocol {
+            public init() {
+            }
             public
             var variable: Bool?
         }
@@ -282,6 +290,8 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         class ServiceProtocolSpy: ServiceProtocol {
+            init() {
+            }
             var variable: Bool?
         }
         """,

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -50,7 +50,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         public class ServiceProtocolSpy: ServiceProtocol {
-            var name: String {
+            public var name: String {
                 get {
                     underlyingName
                 }
@@ -59,7 +59,7 @@ final class UT_SpyableMacro: XCTestCase {
                 }
             }
             var underlyingName: (String)!
-            var anyProtocol: any Codable {
+            public var anyProtocol: any Codable {
                 get {
                     underlyingAnyProtocol
                 }
@@ -69,7 +69,7 @@ final class UT_SpyableMacro: XCTestCase {
             }
             var underlyingAnyProtocol: (any Codable)!
             var secondName: String?
-            var added: () -> Void {
+            public var added: () -> Void {
                 get {
                     underlyingAdded
                 }

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -49,7 +49,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        class ServiceProtocolSpy: ServiceProtocol {
+        public class ServiceProtocolSpy: ServiceProtocol {
             var name: String {
                 get {
                     underlyingName
@@ -199,10 +199,56 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         #if CUSTOM
-        class ServiceProtocolSpy: ServiceProtocol {
+        public class ServiceProtocolSpy: ServiceProtocol {
             var variable: Bool?
         }
         #endif
+        """,
+      macros: sut
+    )
+  }
+
+  func testMacroWithNoFlag() {
+    let protocolDeclaration = """
+      public protocol ServiceProtocol {
+          var variable: Bool? { get set }
+      }
+      """
+    assertMacroExpansion(
+      """
+      @Spyable(behindPreprocessorFlag: nil)
+      \(protocolDeclaration)
+      """,
+      expandedSource: """
+
+        \(protocolDeclaration)
+
+        public class ServiceProtocolSpy: ServiceProtocol {
+            var variable: Bool?
+        }
+        """,
+      macros: sut
+    )
+  }
+
+  func testMacroInternal() {
+    let protocolDeclaration = """
+      protocol ServiceProtocol {
+          var variable: Bool? { get set }
+      }
+      """
+    assertMacroExpansion(
+      """
+      @Spyable(behindPreprocessorFlag: nil)
+      \(protocolDeclaration)
+      """,
+      expandedSource: """
+
+        \(protocolDeclaration)
+
+        class ServiceProtocolSpy: ServiceProtocol {
+            var variable: Bool?
+        }
         """,
       macros: sut
     )


### PR DESCRIPTION
- Allows protocols with *any* modifiers, like `public`, `fileprivate` etc. to inherit this access on the spy and all the generated members. This is done by taking the `modifiers` on the original protocol definition and applying it to all generated members.
  - `private` protocol members will inherit an access level `fileprivate` instead. A `protocol` declared `private` at file-scope is effectively treated as `fileprivate`. This access level on the generated members is required to satisfy the protocol requirements
- Generate an `init` with the same access level, allowing the spy to be created outside of the current module (as the default init level is `internal`).
- Adds tests for all use cases.
- Closes #73 , fixes #72

---

Thanks for the great library! This is the best spy/mock generator out there atm.