### PR TITLE
Fix to search for 'Spyable' in AttributeListSyntax when checking behindPreprocessorFlag.

### DIFF
--- a/Sources/SpyableMacro/Macro/SpyableMacro.swift
+++ b/Sources/SpyableMacro/Macro/SpyableMacro.swift
@@ -61,7 +61,11 @@ public enum SpyableMacro: PeerMacro {
 extension DeclSyntaxProtocol {
   /// - Returns: The preprocessor `flag` parameter that can be optionally provided via `@Spyable(flag:)`.
   fileprivate var preprocessorFlag: String? {
-    self.as(ProtocolDeclSyntax.self)?.attributes.first?
+    self
+      .as(ProtocolDeclSyntax.self)?.attributes.first {
+        $0.as(AttributeSyntax.self)?.attributeName
+          .as(IdentifierTypeSyntax.self)?.name.text == "Spyable"
+      }?
       .as(AttributeSyntax.self)?.arguments?
       .as(LabeledExprListSyntax.self)?.first {
         $0.label?.text == "behindPreprocessorFlag"

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -207,4 +207,33 @@ final class UT_SpyableMacro: XCTestCase {
       macros: sut
     )
   }
+  
+  func testMacroWithFlagMultipleAttributes() {
+    let protocolDeclaration = """
+      public protocol ServiceProtocol {
+          var variable: Bool? { get set }
+      }
+      """
+    assertMacroExpansion(
+      """
+      @MainActor
+      @Spyable(behindPreprocessorFlag: "CUSTOM")
+      @available(*, deprecated)
+      \(protocolDeclaration)
+      """,
+      expandedSource: """
+        
+        @MainActor
+        @available(*, deprecated)
+        \(protocolDeclaration)
+        
+        #if CUSTOM
+        class ServiceProtocolSpy: ServiceProtocol {
+            var variable: Bool?
+        }
+        #endif
+        """,
+      macros: sut
+    )
+  }
 }

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -207,7 +207,7 @@ final class UT_SpyableMacro: XCTestCase {
       macros: sut
     )
   }
-  
+
   func testMacroWithFlagMultipleAttributes() {
     let protocolDeclaration = """
       public protocol ServiceProtocol {
@@ -222,11 +222,11 @@ final class UT_SpyableMacro: XCTestCase {
       \(protocolDeclaration)
       """,
       expandedSource: """
-        
+
         @MainActor
         @available(*, deprecated)
         \(protocolDeclaration)
-        
+
         #if CUSTOM
         class ServiceProtocolSpy: ServiceProtocol {
             var variable: Bool?


### PR DESCRIPTION
Resolve #79 

Hello 👋
Fix to search for `Spyable` in `AttributeListSyntax` when checking `behindPreprocessorFlag` and add test case.