### PR TITLE
added expectation factory

### DIFF
--- a/Sources/SpyableMacro/Factories/ExpectationFactory.swift
+++ b/Sources/SpyableMacro/Factories/ExpectationFactory.swift
@@ -1,0 +1,82 @@
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+/// The `ExpectationFactory` is designed to generate a representation of a Swift
+/// variable declaration for an expectation, as well as invocation of it's fulfillments.
+///
+/// The generated variable represents aт XCTestExpectation that corresponds to a given function
+/// signature. The name of the variable is constructed by appending the word "Expectation"
+/// to the `variablePrefix` parameter.
+///
+/// The factory also generates a call expression that fulfils that expectation 
+///
+/// The following code:
+/// ```swift
+/// var fooExpectation: XCTestExpectation?
+///
+/// fooExpectation?.fulfill()
+/// ```
+/// would be generated for a function like this:
+/// ```swift
+/// func foo()
+///
+/// - Note: The `ExpectationFactory` is useful in scenarios where you need to receive a signal
+///         that async function did finish it's execution
+struct ExpectationFactory {
+  func variableDeclaration(
+    variablePrefix: String,
+    functionSignature: FunctionSignatureSyntax
+  ) throws -> VariableDeclSyntax {
+    let elements = TupleTypeElementListSyntax {
+      TupleTypeElementSyntax(
+        type: FunctionTypeSyntax(
+          parameters: TupleTypeElementListSyntax {
+            for parameter in functionSignature.parameterClause.parameters {
+              TupleTypeElementSyntax(type: parameter.type)
+            }
+          },
+          effectSpecifiers: TypeEffectSpecifiersSyntax(
+            asyncSpecifier: functionSignature.effectSpecifiers?.asyncSpecifier,
+            throwsSpecifier: functionSignature.effectSpecifiers?.throwsSpecifier
+          ),
+          returnClause: functionSignature.returnClause
+            ?? ReturnClauseSyntax(
+              type: IdentifierTypeSyntax(
+                name: .identifier("Void")
+              )
+            )
+        )
+      )
+    }
+
+    return try VariableDeclSyntax(
+      """
+      var \(variableIdentifier(variablePrefix: variablePrefix)): XCTestExpectation?
+      """
+    )
+  }
+    
+  func fulfillExpectationExpression(variablePrefix: String) -> ExprSyntax {
+    ExprSyntax(
+      """
+      \(variableIdentifier(variablePrefix: variablePrefix))?.fulfill()
+      """
+        )
+  }
+
+  private func variableIdentifier(variablePrefix: String) -> TokenSyntax {
+    TokenSyntax.identifier(variablePrefix + "Expectation")
+  }
+}
+
+extension FunctionParameterListSyntax.Element {
+  fileprivate var isInoutParameter: Bool {
+    if let attributedType = self.type.as(AttributedTypeSyntax.self),
+      attributedType.specifier?.text == TokenSyntax.keyword(.inout).text
+    {
+      return true
+    } else {
+      return false
+    }
+  }
+}

--- a/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/FunctionImplementationFactory.swift
@@ -61,6 +61,7 @@ struct FunctionImplementationFactory {
   private let receivedInvocationsFactory = ReceivedInvocationsFactory()
   private let throwableErrorFactory = ThrowableErrorFactory()
   private let closureFactory = ClosureFactory()
+  private let expectationFactory = ExpectationFactory()
   private let returnValueFactory = ReturnValueFactory()
 
   func declaration(
@@ -102,6 +103,8 @@ struct FunctionImplementationFactory {
           protocolFunctionDeclaration: protocolFunctionDeclaration
         )
       }
+        
+      expectationFactory.fulfillExpectationExpression(variablePrefix: variablePrefix)
     }
 
     return spyFunctionDeclaration

--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -90,6 +90,7 @@ struct SpyFactory {
   private let throwableErrorFactory = ThrowableErrorFactory()
   private let returnValueFactory = ReturnValueFactory()
   private let closureFactory = ClosureFactory()
+  private let expectationFactory = ExpectationFactory()
   private let functionImplementationFactory = FunctionImplementationFactory()
 
   func classDeclaration(for protocolDeclaration: ProtocolDeclSyntax) throws -> ClassDeclSyntax {
@@ -152,6 +153,11 @@ struct SpyFactory {
           }
 
           try closureFactory.variableDeclaration(
+            variablePrefix: variablePrefix,
+            functionSignature: functionDeclaration.signature
+          )
+            
+          try expectationFactory.variableDeclaration(
             variablePrefix: variablePrefix,
             functionSignature: functionDeclaration.signature
           )


### PR DESCRIPTION
When working with Swift concurrency it's useful for a Spy object to feature an XCTestExpectation variable so that it can be called at the end of the function. 
Later in a test that facilitates the assertion whether the function was/wasn't called