### PR TITLE
Support returning existential types in functions

### DIFF
--- a/Examples/Sources/ViewModel.swift
+++ b/Examples/Sources/ViewModel.swift
@@ -14,6 +14,7 @@ protocol ServiceProtocol {
   func save(name: any Codable, surname: any Codable)
   func insert(name: (any Codable)?, surname: (any Codable)?)
   func append(name: (any Codable) -> (any Codable)?)
+  func get() async throws -> any Codable
 }
 
 final class ViewModel {

--- a/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
+++ b/Sources/SpyableMacro/Factories/ReturnValueFactory.swift
@@ -42,14 +42,37 @@ struct ReturnValueFactory {
     variablePrefix: String,
     functionReturnType: TypeSyntax
   ) throws -> VariableDeclSyntax {
-    let typeAnnotation =
-      if functionReturnType.is(OptionalTypeSyntax.self) {
-        TypeAnnotationSyntax(type: functionReturnType)
-      } else {
-        TypeAnnotationSyntax(
-          type: ImplicitlyUnwrappedOptionalTypeSyntax(wrappedType: functionReturnType)
+    /*
+     func f() -> String?
+     */
+    let typeAnnotation = if functionReturnType.is(OptionalTypeSyntax.self) {
+      TypeAnnotationSyntax(type: functionReturnType)
+    /*
+     func f() -> String!
+     */
+    } else if functionReturnType.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+      TypeAnnotationSyntax(type: functionReturnType)
+    /*
+     func f() -> any Codable
+     */
+    } else if functionReturnType.is(SomeOrAnyTypeSyntax.self) {
+      TypeAnnotationSyntax(
+        type: ImplicitlyUnwrappedOptionalTypeSyntax(
+          wrappedType: TupleTypeSyntax(
+            elements: TupleTypeElementListSyntax {
+              TupleTypeElementSyntax(type: functionReturnType)
+            }
+          )
         )
-      }
+      )
+    /*
+     func f() -> String
+     */
+    } else {
+      TypeAnnotationSyntax(
+        type: ImplicitlyUnwrappedOptionalTypeSyntax(wrappedType: functionReturnType)
+      )
+    }
 
     return try VariableDeclSyntax(
       """

--- a/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_ReturnValueFactory.swift
@@ -15,11 +15,19 @@ final class UT_ReturnValueFactory: XCTestCase {
     )
   }
 
-  func testVariableDeclarationOptionType() throws {
+  func testVariableDeclarationOptionalType() throws {
     try assert(
       functionReturnType: "String?",
       prefixForVariable: "_prefix_",
       expectingVariableDeclaration: "var _prefix_ReturnValue: String?"
+    )
+  }
+
+  func testVariableDeclarationExistentialType() throws {
+    try assert(
+      functionReturnType: "any Codable",
+      prefixForVariable: "_prefix_",
+      expectingVariableDeclaration: "var _prefix_ReturnValue: (any Codable)!"
     )
   }
 

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -319,6 +319,34 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
+  func testDeclarationReturnsExistential() throws {
+    try assertProtocol(
+      withDeclaration: """
+        protocol ServiceProtocol {
+            func foo() -> any Codable
+        }
+        """,
+      expectingClassDeclaration: """
+        class ServiceProtocolSpy: ServiceProtocol {
+            var fooCallsCount = 0
+            var fooCalled: Bool {
+                return fooCallsCount > 0
+            }
+            var fooReturnValue: (any Codable)!
+            var fooClosure: (() -> any Codable)?
+            func foo() -> any Codable {
+                fooCallsCount += 1
+                if fooClosure != nil {
+                    return fooClosure!()
+                } else {
+                    return fooReturnValue
+                }
+            }
+        }
+        """
+    )
+  }
+
   func testDeclarationVariable() throws {
     try assertProtocol(
       withDeclaration: """


### PR DESCRIPTION
Add support for such a functions:
```swift
@Spyable protocol Foo {
  func get() -> any Codable
}
```