### PR TITLE
Support variable declaration with forced unwrapped type

### DIFF
--- a/Examples/Sources/ViewModel.swift
+++ b/Examples/Sources/ViewModel.swift
@@ -5,6 +5,7 @@ protocol ServiceProtocol {
   var name: String { get }
   var anyProtocol: any Codable { get set }
   var secondName: String? { get }
+  var address: String! { get }
   var added: () -> Void { get set }
   var removed: (() -> Void)? { get set }
 

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -53,8 +53,16 @@ struct VariablesImplementationFactory {
       // Since the count of `bindings` is exactly 1, it is safe to force unwrap it.
       let binding = protocolVariableDeclaration.bindings.first!
 
-      if binding.typeAnnotation?.type.is(OptionalTypeSyntax.self) == true {
+      /*
+       var name: String?
+       var name: String!
+       */
+      if binding.typeAnnotation?.type.is(OptionalTypeSyntax.self) == true ||
+          binding.typeAnnotation?.type.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) == true {
         accessorRemovalVisitor.visit(protocolVariableDeclaration)
+      /*
+       var name: String
+       */
       } else {
         try protocolVariableDeclarationWithGetterAndSetter(binding: binding)
 

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -413,6 +413,21 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
+  func testDeclarationForcedUnwrappedVariable() throws {
+    try assertProtocol(
+      withDeclaration: """
+        protocol ServiceProtocol {
+            var data: String! { get set }
+        }
+        """,
+      expectingClassDeclaration: """
+        class ServiceProtocolSpy: ServiceProtocol {
+            var data: String!
+        }
+        """
+    )
+  }
+
   func testDeclarationExistentialVariable() throws {
     try assertProtocol(
       withDeclaration: """

--- a/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_VariablesImplementationFactory.swift
@@ -31,6 +31,13 @@ final class UT_VariablesImplementationFactory: XCTestCase {
     )
   }
 
+  func testVariablesDeclarationsForcedUnwrapped() throws {
+    try assertProtocolVariable(
+      withVariableDeclaration: "var foo: String! { get }",
+      expectingVariableDeclaration: "var foo: String!"
+    )
+  }
+
   func testVariablesDeclarationsClosure() throws {
     try assertProtocolVariable(
       withVariableDeclaration: "var completion: () -> Void { get }",


### PR DESCRIPTION
Resolve #95 

Add support for such a declaration:
```swift
@Spyable protocol Foo {
  var name: String!
}
```