### PR TITLE
Add Support for Swift 6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
     strategy:
       matrix:
         xcode:
+          - '16.1'
           - '16.0'
           - '15.4'
         package:

--- a/Examples/Package.resolved
+++ b/Examples/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Examples/Package@swift-6.0.swift
+++ b/Examples/Package@swift-6.0.swift
@@ -1,0 +1,38 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Examples",
+  platforms: [
+    .macOS(.v10_15),
+    .iOS(.v13),
+    .tvOS(.v13),
+    .watchOS(.v6),
+    .macCatalyst(.v13),
+  ],
+  products: [
+    .library(
+      name: "Examples",
+      targets: ["Examples"]
+    )
+  ],
+  dependencies: [
+    .package(name: "swift-spyable", path: "../")
+  ],
+  targets: [
+    .target(
+      name: "Examples",
+      dependencies: [
+        .product(name: "Spyable", package: "swift-spyable")
+      ],
+      path: "Sources"
+    ),
+    .testTarget(
+      name: "ExamplesTests",
+      dependencies: ["Examples"],
+      path: "Tests"
+    ),
+  ],
+  swiftLanguageModes: [.v6]
+)

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax",
       "state" : {
-        "revision" : "303e5c5c36d6a558407d364878df131c3546fad8",
-        "version" : "510.0.2"
+        "revision" : "0687f71944021d616d34d922343dcef086855920",
+        "version" : "600.0.1"
       }
     }
   ],

--- a/Package@swift-6.0.swift
+++ b/Package@swift-6.0.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import CompilerPluginSupport
 import PackageDescription
@@ -42,5 +42,6 @@ let package = Package(
         .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax"),
       ]
     ),
-  ]
+  ],
+  swiftLanguageModes: [.v6]
 )

--- a/Sources/SpyableMacro/Extensions/TypeSyntax+Extensions.swift
+++ b/Sources/SpyableMacro/Extensions/TypeSyntax+Extensions.swift
@@ -101,6 +101,8 @@ extension ArrayTypeSyntax: TypeSyntaxSupportingGenerics {
   }
 }
 
+extension GenericArgumentClauseSyntax: @retroactive TypeSyntaxProtocol {}
+
 extension GenericArgumentClauseSyntax: TypeSyntaxSupportingGenerics {
   fileprivate var nestedTypeSyntaxes: [TypeSyntax] {
     arguments.map { $0.argument }

--- a/Sources/SpyableMacro/Extensions/TypeSyntax+Extensions.swift
+++ b/Sources/SpyableMacro/Extensions/TypeSyntax+Extensions.swift
@@ -101,7 +101,9 @@ extension ArrayTypeSyntax: TypeSyntaxSupportingGenerics {
   }
 }
 
+#if compiler(>=6.0)
 extension GenericArgumentClauseSyntax: @retroactive TypeSyntaxProtocol {}
+#endif
 
 extension GenericArgumentClauseSyntax: TypeSyntaxSupportingGenerics {
   fileprivate var nestedTypeSyntaxes: [TypeSyntax] {

--- a/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
+++ b/Sources/SpyableMacro/Factories/VariablesImplementationFactory.swift
@@ -43,8 +43,6 @@ import SwiftSyntaxBuilder
 /// - Important: The variable declaration must have exactly one binding. Any deviation from this will result in
 ///              an error diagnostic produced by the macro.
 struct VariablesImplementationFactory {
-  private let accessorRemovalVisitor = AccessorRemovalVisitor()
-
   @MemberBlockItemListBuilder
   func variablesDeclarations(
     protocolVariableDeclaration: VariableDeclSyntax
@@ -60,6 +58,7 @@ struct VariablesImplementationFactory {
       if binding.typeAnnotation?.type.is(OptionalTypeSyntax.self) == true
         || binding.typeAnnotation?.type.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) == true
       {
+        let accessorRemovalVisitor = AccessorRemovalVisitor()
         accessorRemovalVisitor.visit(protocolVariableDeclaration)
         /*
        var name: String


### PR DESCRIPTION
1. **CI Workflow**:
   - Added Xcode 16.1 to the CI matrix.

2. **Dependencies**:
   - Upgraded `swift-syntax` to version `600.0.1`.
   - Updated dependency constraints to support SwiftSyntax up to `600.0.0`.

3. **Swift 6.0 Support**:
   - Introduced `Package@swift-6.0.swift` files for both the main package and examples.

4. **Code Improvements**:
   - Added retroactive conformance for `GenericArgumentClauseSyntax`.
   - Refactored `VariablesImplementationFactory` for cleaner code.
