### PR TITLE
Support `Sendable` conformed protocol

### DIFF
--- a/Sources/SpyableMacro/Factories/SpyFactory.swift
+++ b/Sources/SpyableMacro/Factories/SpyFactory.swift
@@ -112,7 +112,10 @@ struct SpyFactory {
       genericParameterClause: genericParameterClause,
       inheritanceClause: InheritanceClauseSyntax {
         InheritedTypeSyntax(
-          type: IdentifierTypeSyntax(name: protocolDeclaration.name)
+          type: TypeSyntax(stringLiteral: protocolDeclaration.name.text)
+        )
+        InheritedTypeSyntax(
+          type: TypeSyntax(stringLiteral: "@unchecked Sendable")
         )
       },
       memberBlockBuilder: {

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -9,7 +9,7 @@ final class UT_SpyFactory: XCTestCase {
     try assertProtocol(
       withDeclaration: "protocol Foo {}",
       expectingClassDeclaration: """
-        class FooSpy: Foo {
+        class FooSpy: Foo, @unchecked Sendable {
             init() {
             }
         }
@@ -25,7 +25,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceSpy: Service {
+        class ServiceSpy: Service, @unchecked Sendable {
             init() {
             }
             var fetchCallsCount = 0
@@ -50,7 +50,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooTextCountCallsCount = 0
@@ -79,7 +79,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooModelCallsCount = 0
@@ -108,7 +108,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooModelCallsCount = 0
@@ -137,7 +137,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooModelCallsCount = 0
@@ -166,7 +166,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooModelCallsCount = 0
@@ -202,7 +202,7 @@ final class UT_SpyFactory: XCTestCase {
     assertBuildResult(
       result,
       """
-      class ViewModelProtocolSpy: ViewModelProtocol {
+      class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
           init() {
           }
           var fooTextValueCallsCount = 0
@@ -236,7 +236,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooActionCallsCount = 0
@@ -265,7 +265,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ViewModelProtocolSpy: ViewModelProtocol {
+        class ViewModelProtocolSpy: ViewModelProtocol, @unchecked Sendable {
             init() {
             }
             var fooActionCallsCount = 0
@@ -290,7 +290,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class BarSpy: Bar {
+        class BarSpy: Bar, @unchecked Sendable {
             init() {
             }
             var printCallsCount = 0
@@ -320,7 +320,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var fooTextCountCallsCount = 0
@@ -354,7 +354,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var fooCallsCount = 0
@@ -392,7 +392,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var fooCallsCount = 0
@@ -422,7 +422,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var fooCallsCount = 0
@@ -452,7 +452,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var data: Data {
@@ -477,7 +477,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var data: Data?
@@ -494,7 +494,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var data: String!
@@ -511,7 +511,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var data: any Codable {
@@ -536,7 +536,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class ServiceProtocolSpy: ServiceProtocol {
+        class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             init() {
             }
             var completion: () -> Void {
@@ -563,7 +563,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class FooSpy<Key: Hashable>: Foo {
+        class FooSpy<Key: Hashable>: Foo, @unchecked Sendable {
             init() {
             }
         }
@@ -580,7 +580,7 @@ final class UT_SpyFactory: XCTestCase {
         }
         """,
       expectingClassDeclaration: """
-        class FooSpy<Key: Hashable, Value>: Foo {
+        class FooSpy<Key: Hashable, Value>: Foo, @unchecked Sendable {
             init() {
             }
         }

--- a/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
+++ b/Tests/SpyableMacroTests/Factories/UT_SpyFactory.swift
@@ -42,6 +42,56 @@ final class UT_SpyFactory: XCTestCase {
     )
   }
 
+  func testDeclarationWithSendable() throws {
+    try assertProtocol(
+      withDeclaration: """
+        protocol Service: Sendable {
+            func fetch()
+        }
+        """,
+      expectingClassDeclaration: """
+        class ServiceSpy: Service, @unchecked Sendable {
+            init() {
+            }
+            var fetchCallsCount = 0
+            var fetchCalled: Bool {
+                return fetchCallsCount > 0
+            }
+            var fetchClosure: (() -> Void)?
+            func fetch() {
+                fetchCallsCount += 1
+                fetchClosure?()
+            }
+        }
+        """
+    )
+  }
+
+  func testDeclarationWithUncheckedSendable() throws {
+    try assertProtocol(
+      withDeclaration: """
+        protocol Service: @unchecked Sendable {
+            func fetch()
+        }
+        """,
+      expectingClassDeclaration: """
+        class ServiceSpy: Service, @unchecked Sendable {
+            init() {
+            }
+            var fetchCallsCount = 0
+            var fetchCalled: Bool {
+                return fetchCallsCount > 0
+            }
+            var fetchClosure: (() -> Void)?
+            func fetch() {
+                fetchCallsCount += 1
+                fetchClosure?()
+            }
+        }
+        """
+    )
+  }
+
   func testDeclarationArguments() throws {
     try assertProtocol(
       withDeclaration: """

--- a/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
+++ b/Tests/SpyableMacroTests/Macro/UT_SpyableMacro.swift
@@ -50,7 +50,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        public class ServiceProtocolSpy: ServiceProtocol {
+        public class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             public init() {
             }
             public var name: String {
@@ -223,7 +223,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -244,7 +244,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -266,7 +266,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         #if CUSTOM
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -293,7 +293,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         #if CUSTOM
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -315,7 +315,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -353,7 +353,7 @@ final class UT_SpyableMacro: XCTestCase {
         let myCustomFlag = "DEBUG"
         \(protocolDeclaration)
 
-        class MyProtocolSpy: MyProtocol {
+        class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             init() {
             }
         }
@@ -404,7 +404,7 @@ final class UT_SpyableMacro: XCTestCase {
 
           \(protocolDefinition)
 
-          \(mapping.spyClassAccessLevel) class ServiceProtocolSpy: ServiceProtocol {
+          \(mapping.spyClassAccessLevel) class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
               \(mapping.spyClassAccessLevel) init() {
               }
               \(mapping.spyClassAccessLevel)
@@ -458,7 +458,7 @@ final class UT_SpyableMacro: XCTestCase {
 
           \(protocolDefinition)
 
-          \(mapping.spyClassAccessLevel) class ServiceProtocolSpy: ServiceProtocol {
+          \(mapping.spyClassAccessLevel) class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
               \(mapping.spyClassAccessLevel) init() {
               }
               \(mapping.spyClassAccessLevel)
@@ -503,7 +503,7 @@ final class UT_SpyableMacro: XCTestCase {
 
         \(protocolDeclaration)
 
-        fileprivate class ServiceProtocolSpy: ServiceProtocol {
+        fileprivate class ServiceProtocolSpy: ServiceProtocol, @unchecked Sendable {
             fileprivate init() {
             }
             fileprivate
@@ -546,7 +546,7 @@ final class UT_SpyableMacro: XCTestCase {
         \(protocolDeclaration)
 
         #if CUSTOM_FLAG
-        package class MyProtocolSpy: MyProtocol {
+        package class MyProtocolSpy: MyProtocol, @unchecked Sendable {
             package init() {
             }
         }


### PR DESCRIPTION
- Resolves: https://github.com/Matejkob/swift-spyable/issues/91

Hello! I fixed an error which occurs in my project.

The following code causes an error on Swift 6.

```swift
@Spyable
protocol XxxProtocol: Sendable {
    func fetch() async throws -> [String]
}

class XxxProtocolSpy: XxxProtocol { // ❌ Non-final class 'XxxProtocolSpy' cannot conform to 'Sendable'; use '@unchecked Sendable'
    var fetchCallsCount = 0 // ❌ Stored property 'fetchCallsCount' of 'Sendable'-conforming class 'XxxProtocolSpy' is mutable
    var fetchCalled: Bool {
        return fetchCallsCount > 0
    }
    var fetchThrowableError: (any Error)?
    var fetchReturnValue: [String]!
    var fetchClosure: (() async throws -> [String])?
    func fetch() async throws -> [String] {
        fetchCallsCount += 1
        if let fetchThrowableError {
            throw fetchThrowableError
        }
        if fetchClosure != nil {
            return try await fetchClosure!()
        } else {
            return fetchReturnValue
        }
    }
}
```

To solve this error, I added `@unchecked Sendable` conformance to all `Spy` classes.

`Sendable` conformed protocol:
```diff
protocol XxxProtocol: Sendable {
    func fetch() async throws -> [String]
}

- class XxxProtocolSpy: XxxProtocol {
+ class XxxProtocolSpy: XxxProtocol, @unchecked Sendable {
...
}
```

not `Sendable` conformed protocol:
```diff
protocol XxxProtocol {
    func fetch() async throws -> [String]
}

- class XxxProtocolSpy: XxxProtocol {
+ class XxxProtocolSpy: XxxProtocol, @unchecked Sendable {
...
}
```